### PR TITLE
typo record/records

### DIFF
--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -222,7 +222,7 @@ public virtual class fflib_SObjectUnitOfWork
 	 **/
 	public void registerDirty(List<SObject> records)
 	{
-		for(SObject record : record)
+		for(SObject record : records)
 		{
 			this.registerDirty(record);
 		}


### PR DESCRIPTION
Simple typo fix that was causing deployment from the git repo to fail.