### PR TITLE
Fix missing variable referenced in test method

### DIFF
--- a/fflib/src/classes/fflib_SObjectMocks.cls
+++ b/fflib/src/classes/fflib_SObjectMocks.cls
@@ -221,7 +221,7 @@ public class fflib_SObjectMocks
 		
 		public void registerDeleted(List<SObject> records)
 		{
-			mocks.mockVoidMethod(this, 'registerDeleted', new List<Object> {record});
+			mocks.mockVoidMethod(this, 'registerDeleted', new List<Object> {records});
 		}
 
 		public void commitWork()


### PR DESCRIPTION
The registerDeleted test method was failing because it referred to a variable called 'record' that wasn't present in the scope. I've updated the reference to 'records' which is in scope.