### PR TITLE
Update to fix deploy, and remove CurrencyIsoCode from RecordType standard object

### DIFF
--- a/fflib/src/classes/fflib_SObjectMocks.cls
+++ b/fflib/src/classes/fflib_SObjectMocks.cls
@@ -221,7 +221,7 @@ public class fflib_SObjectMocks
 		
 		public void registerDeleted(List<SObject> records)
 		{
-			mocks.mockVoidMethod(this, 'registerDeleted', new List<Object> {record});
+			mocks.mockVoidMethod(this, 'registerDeleted', new List<Object> {records});
 		}
 
 		public void commitWork()

--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -35,7 +35,8 @@ public abstract with sharing class fflib_SObjectSelector
      **/
     private static Set<String> STANDARD_WITHOUT_CURRENCYISO = new Set<String> { AsyncApexJob.SObjectType.getDescribe().getName()
                                                                                 , ApexClass.SObjectType.getDescribe().getName()
-                                                                                , Attachment.SObjectType.getDescribe().getName()  };
+                                                                                , Attachment.SObjectType.getDescribe().getName()
+                                                                                , RecordType.getSObjectType.getDescribe().getName() };
      
     /**
      * Should this selector automatically include the FieldSet fields when building queries?


### PR DESCRIPTION
Line 224 was referencing 'record' variable instead of 'records' so would not deploy.