### PR TITLE
Issue #56 - Add event notifications to commitWork processing

### DIFF
--- a/fflib/src/classes/fflib_Application.cls
+++ b/fflib/src/classes/fflib_Application.cls
@@ -62,6 +62,22 @@ public class fflib_Application
 			return new fflib_SObjectUnitOfWork(m_objectTypes);
 		}
 
+		/**
+		 * Returns a new fflib_SObjectUnitOfWork configured with the 
+		 *   SObjectType list specified, returns a Mock implementation
+		 *   if set via the setMock method
+		 *
+		 * @remark If mock is set, the list of SObjectType in the mock could be different
+		 *         then the list of SObjectType specified in this method call
+		 **/
+		public fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes)
+		{
+			// Mock?
+			if(m_mockUow!=null)
+				return m_mockUow;
+			return new fflib_SObjectUnitOfWork(objectTypes);
+		}
+
 		@TestVisible
 		private void setMock(fflib_ISObjectUnitOfWork mockUow)
 		{

--- a/fflib/src/classes/fflib_Application.cls
+++ b/fflib/src/classes/fflib_Application.cls
@@ -62,22 +62,6 @@ public class fflib_Application
 			return new fflib_SObjectUnitOfWork(m_objectTypes);
 		}
 
-		/**
-		 * Returns a new fflib_SObjectUnitOfWork configured with the 
-		 *   SObjectType list specified, returns a Mock implementation
-		 *   if set via the setMock method
-		 *
-		 * @remark If mock is set, the list of SObjectType in the mock could be different
-		 *         then the list of SObjectType specified in this method call
-		 **/
-		public fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes)
-		{
-			// Mock?
-			if(m_mockUow!=null)
-				return m_mockUow;
-			return new fflib_SObjectUnitOfWork(objectTypes);
-		}
-
 		@TestVisible
 		private void setMock(fflib_ISObjectUnitOfWork mockUow)
 		{

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -130,6 +130,7 @@ public virtual class fflib_SObjectUnitOfWork
 	public virtual void onDMLFinished() {}
 	public virtual void onDoWorkStarting() {}
 	public virtual void onDoWorkFinished() {}
+	public virtual void onCommitWorkFinishing() {}
 	public virtual void onCommitWorkFinished(Boolean wasSuccessful) {}
 
 	/**
@@ -319,6 +320,9 @@ public virtual class fflib_SObjectUnitOfWork
 				work.doWork();
 			// notify we've completed processing registered work
 			onDoWorkFinished();
+
+			// notify we've completed all steps and are in the final stage of completing
+			onCommitWorkFinishing();
 
 			// mark tracker to indicate success
 			wasSuccessful = true;

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -114,10 +114,8 @@ public virtual class fflib_SObjectUnitOfWork
 			
 		for(Schema.SObjectType sObjectType : m_sObjectTypes)
 		{
-			m_newListByType.put(sObjectType.getDescribe().getName(), new List<SObject>());
-			m_dirtyMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
-			m_deletedMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
-			m_relationships.put(sObjectType.getDescribe().getName(), new Relationships());	
+			// register the type
+			handleRegisterType(sObjectType);
 		}
 
 		m_workList.add(m_emailWork);
@@ -125,6 +123,33 @@ public virtual class fflib_SObjectUnitOfWork
 		m_dml = dml;
 	}
 
+	// default implementations for commitWork events
+	public virtual void onRegisterType(Schema.SObjectType sObjectType) {}
+	public virtual void onCommitWorkStarting() {}
+	public virtual void onDMLStarting() {}
+	public virtual void onDMLFinished() {}
+	public virtual void onDoWorkStarting() {}
+	public virtual void onDoWorkFinished() {}
+	public virtual void onCommitWorkFinished(Boolean wasSuccessful) {}
+
+	/**
+	 * Registers the type to be used for DML operations
+	 *
+	 * @param sObjectType - The type to register
+	 *
+	 */
+	private void handleRegisterType(Schema.SObjectType sObjectType)
+	{
+		// add type to dml operation tracking
+		m_newListByType.put(sObjectType.getDescribe().getName(), new List<SObject>());
+		m_dirtyMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
+		m_deletedMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
+		m_relationships.put(sObjectType.getDescribe().getName(), new Relationships());	
+
+		// give derived class opportunity to register the type
+		onRegisterType(sObjectType);		
+	}
+	
 	/**
 	 * Register a generic peace of work to be invoked during the commitWork phase
 	 **/
@@ -261,10 +286,16 @@ public virtual class fflib_SObjectUnitOfWork
 	 **/
 	public void commitWork()
 	{
+		// notify we're starting the commit work
+		onCommitWorkStarting();
+
 		// Wrap the work in its own transaction 
-		Savepoint sp = Database.setSavePoint();		
+		Savepoint sp = Database.setSavePoint();
+		Boolean wasSuccessful = false;	
 		try
 		{		
+			// notify we're starting the DML operations
+			onDMLStarting();
 			// Insert by type
 			for(Schema.SObjectType sObjectType : m_sObjectTypes)
 			{
@@ -278,9 +309,19 @@ public virtual class fflib_SObjectUnitOfWork
 			Integer objectIdx = m_sObjectTypes.size() - 1;
 			while(objectIdx>=0)
 				m_dml.dmlDelete(m_deletedMapByType.get(m_sObjectTypes[objectIdx--].getDescribe().getName()).values());
+			// notify we're done with DML
+			onDMLFinished();
+
+			// notify we're starting to process registered work
+			onDoWorkStarting();
 			// Generic work
 			for(IDoWork work : m_workList)
 				work.doWork();
+			// notify we've completed processing registered work
+			onDoWorkFinished();
+
+			// mark tracker to indicate success
+			wasSuccessful = true;
 		}
 		catch (Exception e)
 		{
@@ -288,6 +329,11 @@ public virtual class fflib_SObjectUnitOfWork
 			Database.rollback(sp);
 			// Throw exception on to caller
 			throw e;
+		}
+		finally
+		{			
+			// notify we're done with commit work
+			onCommitWorkFinished(wasSuccessful);
 		}
 	}
 	

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -164,4 +164,255 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 		System.assertEquals(9, opps[8].OpportunityLineItems.size());
 		System.assertEquals(10, opps[9].OpportunityLineItems.size());
 	}
+
+	/**
+	 * Create uow with new records and commit
+	 *
+	 *	Testing: 
+	 *
+	 *		- Correct events are fired when commitWork completes successfully
+	 *
+	 */
+	@isTest
+	private static void testDerivedUnitOfWork_CommitSuccess() 
+	{
+		// Insert Opporunities with UnitOfWork
+		DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
+		for(Integer o=0; o<10; o++)
+		{
+			Opportunity opp = new Opportunity();
+			opp.Name = 'UoW Test Name ' + o;
+			opp.StageName = 'Open';
+			opp.CloseDate = System.today();
+			uow.registerNew(new List<SObject>{opp});
+			for(Integer i=0; i<o+1; i++)
+			{
+				Product2 product = new Product2();
+				product.Name = opp.Name + ' : Product : ' + i;
+				uow.registerNew(new List<SObject>{product});
+				PricebookEntry pbe = new PricebookEntry();
+				pbe.UnitPrice = 10;
+				pbe.IsActive = true;
+				pbe.UseStandardPrice = false;
+				pbe.Pricebook2Id = Test.getStandardPricebookId();
+				uow.registerNew(pbe, PricebookEntry.Product2Id, product);
+				OpportunityLineItem oppLineItem = new OpportunityLineItem();
+				oppLineItem.Quantity = 1;
+				oppLineItem.TotalPrice = 10;
+				uow.registerRelationship(oppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
+				uow.registerNew(oppLineItem, OpportunityLineItem.OpportunityId, opp);
+			}
+		}
+		uow.commitWork();
+		
+		// Assert Results 
+		assertResults('UoW');
+
+		assertEvents(new Set<String> {
+				'onCommitWorkStarting'
+				, 'onDMLStarting'
+				, 'onDMLFinished'
+				, 'onDoWorkStarting'
+				, 'onDoWorkFinished'
+				, 'onCommitWorkFinished - true'
+			}
+			, uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
+	}
+
+	/**
+	 * Create uow with data that results in DML Exception
+	 *
+	 *	Testing: 
+	 *
+	 *		- Correct events are fired when commitWork fails during DML processing
+	 *
+	 */
+	@isTest
+	private static void testDerivedUnitOfWork_CommitDMLFail() 
+	{
+		// Insert Opporunities with UnitOfWork forcing a failure on DML by not setting 'Name' field
+		DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
+		Opportunity opp = new Opportunity();
+		uow.registerNew(new List<SObject>{opp});
+		Boolean didFail = false;
+		System.DmlException caughtEx = null;
+
+		try {
+			uow.commitWork();    
+		}
+		catch (System.DmlException dmlex) {
+			didFail = true;
+			caughtEx = dmlex;
+		}	
+		
+		// Assert Results 
+		System.assertEquals(didFail, true, 'didFail');
+		System.assert(caughtEx.getMessage().contains('REQUIRED_FIELD_MISSING'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
+
+		assertEvents(new Set<String> { 
+				'onCommitWorkStarting'
+				, 'onDMLStarting'
+				, 'onCommitWorkFinished - false' 
+			}
+			, uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
+	}
+
+	/**
+	 * Create uow with work that fails
+	 *
+	 *	Testing: 
+	 *
+	 *		- Correct events are fired when commitWork fails during DoWork processing
+	 *
+	 */
+	@isTest
+	private static void testDerivedUnitOfWork_CommitDoWorkFail() 
+	{
+		// Insert Opporunities with UnitOfWork
+		DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
+		Opportunity opp = new Opportunity();
+		opp.Name = 'UoW Test Name 1';
+		opp.StageName = 'Open';
+		opp.CloseDate = System.today();
+		uow.registerNew(new List<SObject>{opp});
+
+		// register work that will fail during processing
+		FailDoingWork fdw = new FailDoingWork();
+		uow.registerWork(fdw);
+
+		Boolean didFail = false;
+		FailDoingWorkException caughtEx = null;
+
+		try {
+			uow.commitWork();    
+		}
+		catch (FailDoingWorkException fdwe) {
+			didFail = true;
+			caughtEx = fdwe;
+		}	
+		
+		// Assert Results 
+		System.assertEquals(didFail, true, 'didFail');
+		System.assert(caughtEx.getMessage().contains('Work failed.'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
+
+		assertEvents(new Set<String> { 
+				'onCommitWorkStarting'
+				, 'onDMLStarting'
+				, 'onDMLFinished'
+				, 'onDoWorkStarting'
+				, 'onCommitWorkFinished - false' 
+			}
+			, uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
+	}	
+
+	/**
+	 * Assert that actual events exactly math expected events (size and type)
+	 */
+	private static void assertEvents(Set<String> expectedEvents, Set<String> actualEvents, Set<Schema.SObjectType> expectedTypes, Set<Schema.SObjectType> actualTypes) 
+	{
+		// assert that events match
+		System.assertEquals(expectedEvents.size(), actualEvents.size(), 'events size');
+		for (String event :expectedEvents)
+		{
+			System.assertEquals(true, actualEvents.contains(event), String.format('Event {0} was not fired.', new List<String> { event }));
+		}
+
+		// assert that types match
+		System.assertEquals(expectedTypes.size(), actualTypes.size(), 'types size');
+		for (Schema.SObjectType sObjectType :expectedTypes)
+		{
+			System.assertEquals(true, actualTypes.contains(sObjectType), String.format('Type {0} was not registered.', new List<String> { sObjectType.getDescribe().getName() }));	
+		}
+	}
+
+	/**
+	 * DoWork implementation that throws exception during processing
+	 */
+	private class FailDoingWork implements fflib_SObjectUnitOfWork.IDoWork
+	{
+		public void doWork()
+		{
+			throw new FailDoingWorkException('Work failed.');
+		}
+	}
+
+	/**
+	 * Derived unit of work that tracks event notifications and handle registration of type
+	 */
+	private class DerivedUnitOfWork extends fflib_SObjectUnitOfWork
+	{
+		private Set<String> m_commitWorkEventsFired = new Set<String>();
+		private Set<Schema.SObjectType> m_registeredTypes = new Set<Schema.SObjectType>();
+
+		public Set<String> getCommitWorkEventsFired()
+		{
+			return m_commitWorkEventsFired.clone();
+		}
+
+		public Set<Schema.SObjectType> getRegisteredTypes()
+		{
+			return m_registeredTypes.clone();
+		}
+
+		public DerivedUnitOfWork(List<Schema.SObjectType> sObjectTypes)
+		{
+			super(sObjectTypes);
+		}
+
+		public DerivedUnitOfWork(List<Schema.SObjectType> sObjectTypes, IDML dml)
+		{
+			super(sObjectTypes, dml);
+		}
+
+		private void addEvent(String event) 
+		{
+			if (m_commitWorkEventsFired.contains(event))
+			{
+				throw new DerivedUnitOfWorkException(String.format('Event {0} has already been fired.', new List<String> { event }));
+			}
+			m_commitWorkEventsFired.add(event);
+		}
+
+		public override void onRegisterType(Schema.SObjectType sObjectType)
+		{
+			if (m_registeredTypes.contains(sObjectType))
+			{
+				throw new DerivedUnitOfWorkException(String.format('Type {0} has already been registered.', new List<String> { sObjectType.getDescribe().getName() }));
+			}
+			m_registeredTypes.add(sObjectType);
+		}
+
+		public override void onCommitWorkStarting()
+		{
+			addEvent('onCommitWorkStarting');
+		}
+
+		public override void onDMLStarting()
+		{
+			addEvent('onDMLStarting');
+		}
+
+		public override void onDMLFinished()
+		{
+			addEvent('onDMLFinished');
+		}		
+
+		public override void onDoWorkStarting()
+		{
+			addEvent('onDoWorkStarting');
+		}
+
+		public override void onDoWorkFinished()
+		{
+			addEvent('onDoWorkFinished');
+		}		
+
+		public override void onCommitWorkFinished(Boolean wasSuccessful)
+		{
+			addEvent('onCommitWorkFinished - ' + wasSuccessful);
+		}
+	}
+
+	public class DerivedUnitOfWorkException extends Exception {}
+	public class FailDoingWorkException extends Exception {}
 }

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -208,12 +208,13 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 		// Assert Results 
 		assertResults('UoW');
 
-		assertEvents(new Set<String> {
+		assertEvents(new List<String> {
 				'onCommitWorkStarting'
 				, 'onDMLStarting'
 				, 'onDMLFinished'
 				, 'onDoWorkStarting'
 				, 'onDoWorkFinished'
+				, 'onCommitWorkFinishing'
 				, 'onCommitWorkFinished - true'
 			}
 			, uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
@@ -249,7 +250,7 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 		System.assertEquals(didFail, true, 'didFail');
 		System.assert(caughtEx.getMessage().contains('REQUIRED_FIELD_MISSING'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
 
-		assertEvents(new Set<String> { 
+		assertEvents(new List<String> { 
 				'onCommitWorkStarting'
 				, 'onDMLStarting'
 				, 'onCommitWorkFinished - false' 
@@ -295,7 +296,7 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 		System.assertEquals(didFail, true, 'didFail');
 		System.assert(caughtEx.getMessage().contains('Work failed.'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
 
-		assertEvents(new Set<String> { 
+		assertEvents(new List<String> { 
 				'onCommitWorkStarting'
 				, 'onDMLStarting'
 				, 'onDMLFinished'
@@ -306,15 +307,16 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 	}	
 
 	/**
-	 * Assert that actual events exactly math expected events (size and type)
+	 * Assert that actual events exactly match expected events (size, order and name)
+	 * and types match expected types
 	 */
-	private static void assertEvents(Set<String> expectedEvents, Set<String> actualEvents, Set<Schema.SObjectType> expectedTypes, Set<Schema.SObjectType> actualTypes) 
+	private static void assertEvents(List<String> expectedEvents, List<String> actualEvents, Set<Schema.SObjectType> expectedTypes, Set<Schema.SObjectType> actualTypes) 
 	{
 		// assert that events match
 		System.assertEquals(expectedEvents.size(), actualEvents.size(), 'events size');
-		for (String event :expectedEvents)
+		for (Integer i = 0; i < expectedEvents.size(); i++)
 		{
-			System.assertEquals(true, actualEvents.contains(event), String.format('Event {0} was not fired.', new List<String> { event }));
+			System.assertEquals(expectedEvents[i], actualEvents[i], String.format('Event {0} was not fired in order expected.', new List<String> { expectedEvents[i] }));
 		}
 
 		// assert that types match
@@ -341,10 +343,10 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 	 */
 	private class DerivedUnitOfWork extends fflib_SObjectUnitOfWork
 	{
-		private Set<String> m_commitWorkEventsFired = new Set<String>();
+		private List<String> m_commitWorkEventsFired = new List<String>();
 		private Set<Schema.SObjectType> m_registeredTypes = new Set<Schema.SObjectType>();
 
-		public Set<String> getCommitWorkEventsFired()
+		public List<String> getCommitWorkEventsFired()
 		{
 			return m_commitWorkEventsFired.clone();
 		}
@@ -366,9 +368,14 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 
 		private void addEvent(String event) 
 		{
-			if (m_commitWorkEventsFired.contains(event))
+			// events should only be fired one time
+			// ensure that this event has not been fired already
+			for (String eventName :m_commitWorkEventsFired)
 			{
-				throw new DerivedUnitOfWorkException(String.format('Event {0} has already been fired.', new List<String> { event }));
+				if (event == eventName)
+				{
+					throw new DerivedUnitOfWorkException(String.format('Event {0} has already been fired.', new List<String> { event }));	
+				}
 			}
 			m_commitWorkEventsFired.add(event);
 		}
@@ -406,6 +413,11 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 		{
 			addEvent('onDoWorkFinished');
 		}		
+
+		public override void onCommitWorkFinishing()
+		{
+			addEvent('onCommitWorkFinishing');
+		}
 
 		public override void onCommitWorkFinished(Boolean wasSuccessful)
 		{


### PR DESCRIPTION
Added event notifications during commitWork at various stages of the process. 

Decided to have discrete "Starting/Finished" for each "operation" to support forward compatibility if other "operations" are added to commitWork.  For example, if something is added in-between DML & DoWork in the future and code was written in onDoWorkStarting assuming it was fired immediately after DML was complete it would lead to unexpected behavior.

Kicked around the idea of having a "Successful" and "Failed" notification instead of just a "Finished(flag)" notification but wanted to keep things as simple as possible while still providing the desired outcome.

Appreciate any feedback to further improve.