### PR TITLE
Issue #57 - expose work related methods on fflib_ISObjectUnitOfWork

### DIFF
--- a/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
@@ -72,4 +72,16 @@ public interface fflib_ISObjectUnitOfWork
 	 * Takes all the work that has been registered with the UnitOfWork and commits it to the database
 	 **/
 	void commitWork();
+	/**
+	 * Register a generic peace of work to be invoked during the commitWork phase
+	 *
+	 * @param work Work to be registered
+	 **/
+	void registerWork(fflib_SObjectUnitOfWork.IDoWork work);
+	/**
+	 * Registers the given email to be sent during the commitWork
+	 *
+	 * @param email Email to be sent
+	 **/	 
+	void registerEmail(Messaging.Email email);
 }

--- a/fflib/src/classes/fflib_SObjectMocks.cls
+++ b/fflib/src/classes/fflib_SObjectMocks.cls
@@ -228,5 +228,15 @@ public class fflib_SObjectMocks
 		{
 			mocks.mockVoidMethod(this, 'commitWork', new List<Object> {});
 		}
+
+		public void registerWork(fflib_SObjectUnitOfWork.IDoWork work)
+		{
+			mocks.mockVoidMethod(this, 'registerWork', new List<Object> {work});
+		}
+
+		public void registerEmail(Messaging.Email email)
+		{
+			mocks.mockVoidMethod(this, 'registerEmail', new List<Object> {email});
+		}
 	}
 }


### PR DESCRIPTION
Per discussion in #57 leaving IDoWork in concrete class and exposing in fflib_ISObjectUnitOfWork