### PR TITLE
Issue #56 - virtualize handle methods

### DIFF
--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -159,7 +159,7 @@ public virtual with sharing class fflib_SObjectDomain
     }
     
     /**
-     * Base handler for the Apex Trigger event Before Update, calls the onBeforeValidate followed by the onBeforeUpdate method
+     * Base handler for the Apex Trigger event Before Update, calls the onBeforeValidate(Map<Id,SObject>) followed by the onBeforeUpdate method
      **/
     public virtual void handleBeforeUpdate(Map<Id,SObject> existingRecords) 
     {

--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -94,6 +94,16 @@ public virtual with sharing class fflib_SObjectDomain
 	}
 	
 	/**
+	 * Override this to apply general validation to be performed before insert, called by the handleBeforeInsert method
+	 **/	
+	public virtual void onBeforeValidate() { }
+
+	/**
+	 * Override this to apply general validation to be performed before update, called by handleBeforeUpdate method
+	 **/
+	public virtual void onBeforeValidate(Map<Id,SObject> existingRecords) { }
+
+	/**
 	 * Override this to apply defaults to the records, this is called by the handleBeforeInsert method
 	 **/
 	public virtual void onApplyDefaults() { }
@@ -143,6 +153,7 @@ public virtual with sharing class fflib_SObjectDomain
 	 **/
     public virtual void handleBeforeInsert() 
     { 
+    	onBeforeValidate();
     	onApplyDefaults(); 
     	onBeforeInsert();
     }
@@ -150,15 +161,16 @@ public virtual with sharing class fflib_SObjectDomain
     /**
      * Base handler for the Apex Trigger event Before Update, calls the onBeforeUpdate method
      **/
-    public void handleBeforeUpdate(Map<Id,SObject> existingRecords) 
+    public virtual void handleBeforeUpdate(Map<Id,SObject> existingRecords) 
     {
+    	onBeforeValidate(existingRecords);    	
     	onBeforeUpdate(existingRecords);
     }
     
     /**
      * Base handler for the Apex Trigger event Before Delete, calls the onBeforeDelete method
      **/
-    public void handleBeforeDelete() 
+    public virtual void handleBeforeDelete() 
     {
     	onBeforeDelete();
     }
@@ -168,7 +180,7 @@ public virtual with sharing class fflib_SObjectDomain
      *
      * @throws DomainException if the current user context is not able to create records
      **/
-    public void handleAfterInsert()
+    public virtual void handleAfterInsert()
     {
     	if(Configuration.EnforcingTriggerCRUDSecurity && !SObjectDescribe.isCreateable()) 
     	   throw new DomainException('Permission to create an ' + SObjectDescribe.getName() + ' denied.');
@@ -182,7 +194,7 @@ public virtual with sharing class fflib_SObjectDomain
      *
      * @throws DomainException if the current user context is not able to update records
      **/
-    public void handleAfterUpdate(Map<Id,SObject> existingRecords) 
+    public virtual void handleAfterUpdate(Map<Id,SObject> existingRecords) 
     {    	
     	if(Configuration.EnforcingTriggerCRUDSecurity && !SObjectDescribe.isUpdateable()) 			    		
     	   throw new DomainException('Permission to udpate an ' + SObjectDescribe.getName() + ' denied.');
@@ -198,7 +210,7 @@ public virtual with sharing class fflib_SObjectDomain
      *
      * @throws DomainException if the current user context is not able to delete records
      **/
-    public void handleAfterDelete() 
+    public virtual void handleAfterDelete() 
     {
     	if(Configuration.EnforcingTriggerCRUDSecurity && !SObjectDescribe.isDeletable())
     	   throw new DomainException('Permission to delete an ' + SObjectDescribe.getName() + ' denied.');
@@ -630,6 +642,37 @@ public virtual with sharing class fflib_SObjectDomain
 			for(Opportunity opportunity : (List<Opportunity>) Records)
 			{
 				opportunity.CloseDate = System.today().addDays(30);						
+			}
+		}
+
+		public override void onBeforeValidate()
+		{
+			// Not required in production code			
+			super.onBeforeValidate();
+
+			// Validate Testfflib_SObjectDomain
+			for(Opportunity opp : (List<Opportunity>) Records)
+			{
+				if((opp.Amount != null) && (opp.Amount > 1000000))
+				{
+					opp.AccountId.addError( error('Amount exceeds your limit.', opp, Opportunity.Amount) );					
+				}			
+			}
+		}
+
+		public override void onBeforeValidate(Map<Id,SObject> existingRecords)
+		{
+			// Not required in production code			
+			super.onBeforeValidate(existingRecords);
+
+			// Validate changes to Testfflib_SObjectDomain
+			for(Opportunity opp : (List<Opportunity>) Records)
+			{
+				Opportunity existingOpp = (Opportunity) existingRecords.get(opp.Id);				
+				if(opp.StageName != existingOpp.StageName && opp.StageName.startsWith('Prospecting'))
+				{
+					opp.StageName.addError( error('You cannot change the Opportunity stage back to Prospecting.', opp, Opportunity.StageName) );
+				}
 			}
 		}
 	

--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -149,7 +149,7 @@ public virtual with sharing class fflib_SObjectDomain
     public virtual void onAfterDelete() { }	
 	
 	/**
-	 * Base handler for the Apex Trigger event Before Insert, calls the onApplyDefaults method, followed by onBeforeInsert
+	 * Base handler for the Apex Trigger event Before Insert, calls the onBeforeValidate, followed by the onApplyDefaults method, followed by onBeforeInsert
 	 **/
     public virtual void handleBeforeInsert() 
     { 
@@ -159,7 +159,7 @@ public virtual with sharing class fflib_SObjectDomain
     }
     
     /**
-     * Base handler for the Apex Trigger event Before Update, calls the onBeforeUpdate method
+     * Base handler for the Apex Trigger event Before Update, calls the onBeforeValidate followed by the onBeforeUpdate method
      **/
     public virtual void handleBeforeUpdate(Map<Id,SObject> existingRecords) 
     {

--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -632,7 +632,7 @@ public virtual with sharing class fflib_SObjectDomain
 				opportunity.CloseDate = System.today().addDays(30);						
 			}
 		}
-
+		
 		public override void onValidate()	
 		{
 			// Not required in production code

--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -632,7 +632,7 @@ public virtual with sharing class fflib_SObjectDomain
 				opportunity.CloseDate = System.today().addDays(30);						
 			}
 		}
-		
+	
 		public override void onValidate()	
 		{
 			// Not required in production code

--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -94,16 +94,6 @@ public virtual with sharing class fflib_SObjectDomain
 	}
 	
 	/**
-	 * Override this to apply general validation to be performed before insert, called by the handleBeforeInsert method
-	 **/	
-	public virtual void onBeforeValidate() { }
-
-	/**
-	 * Override this to apply general validation to be performed before update, called by handleBeforeUpdate method
-	 **/
-	public virtual void onBeforeValidate(Map<Id,SObject> existingRecords) { }
-
-	/**
 	 * Override this to apply defaults to the records, this is called by the handleBeforeInsert method
 	 **/
 	public virtual void onApplyDefaults() { }
@@ -149,21 +139,19 @@ public virtual with sharing class fflib_SObjectDomain
     public virtual void onAfterDelete() { }	
 	
 	/**
-	 * Base handler for the Apex Trigger event Before Insert, calls the onBeforeValidate, followed by the onApplyDefaults method, followed by onBeforeInsert
+	 * Base handler for the Apex Trigger event Before Insert, calls the onApplyDefaults method, followed by onBeforeInsert
 	 **/
     public virtual void handleBeforeInsert() 
     { 
-    	onBeforeValidate();
     	onApplyDefaults(); 
     	onBeforeInsert();
     }
     
     /**
-     * Base handler for the Apex Trigger event Before Update, calls the onBeforeValidate(Map<Id,SObject>) followed by the onBeforeUpdate method
+     * Base handler for the Apex Trigger event Before Update, calls the onBeforeUpdate method
      **/
     public virtual void handleBeforeUpdate(Map<Id,SObject> existingRecords) 
     {
-    	onBeforeValidate(existingRecords);    	
     	onBeforeUpdate(existingRecords);
     }
     
@@ -645,37 +633,6 @@ public virtual with sharing class fflib_SObjectDomain
 			}
 		}
 
-		public override void onBeforeValidate()
-		{
-			// Not required in production code			
-			super.onBeforeValidate();
-
-			// Validate Testfflib_SObjectDomain
-			for(Opportunity opp : (List<Opportunity>) Records)
-			{
-				if((opp.Amount != null) && (opp.Amount > 1000000))
-				{
-					opp.AccountId.addError( error('Amount exceeds your limit.', opp, Opportunity.Amount) );					
-				}			
-			}
-		}
-
-		public override void onBeforeValidate(Map<Id,SObject> existingRecords)
-		{
-			// Not required in production code			
-			super.onBeforeValidate(existingRecords);
-
-			// Validate changes to Testfflib_SObjectDomain
-			for(Opportunity opp : (List<Opportunity>) Records)
-			{
-				Opportunity existingOpp = (Opportunity) existingRecords.get(opp.Id);				
-				if(opp.StageName != existingOpp.StageName && opp.StageName.startsWith('Prospecting'))
-				{
-					opp.StageName.addError( error('You cannot change the Opportunity stage back to Prospecting.', opp, Opportunity.StageName) );
-				}
-			}
-		}
-	
 		public override void onValidate()	
 		{
 			// Not required in production code

--- a/fflib/src/classes/fflib_SObjectDomainTest.cls
+++ b/fflib/src/classes/fflib_SObjectDomainTest.cls
@@ -36,6 +36,16 @@ private with sharing class fflib_SObjectDomainTest
 		System.assertEquals('You must provide an Account for Opportunities for existing Customers.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(Opportunity.AccountId, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
 	}
+
+	@IsTest
+	private static void testBeforeValidationWithoutDML()
+	{
+		fflib_SObjectDomain.TestSObjectDomain opps = new fflib_SObjectDomain.TestSObjectDomain(new Opportunity[] { new Opportunity ( Name = 'Test', Amount = 2000000 ) } );
+		opps.onBeforeValidate();
+		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());		
+		System.assertEquals('Amount exceeds your limit.', fflib_SObjectDomain.Errors.getAll()[0].message);
+		System.assertEquals(Opportunity.Amount, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
+	}	
 	
 	@IsTest
 	private static void testInsertValidationFailedWithoutDML()
@@ -49,6 +59,19 @@ private with sharing class fflib_SObjectDomainTest
 		System.assertEquals('You must provide an Account for Opportunities for existing Customers.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(Opportunity.AccountId, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
 	}
+
+	@IsTest
+	private static void testInsertBeforeValidationFailedWithoutDML()
+	{
+		Opportunity opp = new Opportunity ( Name = 'Test', Amount = 2000000 );
+		System.assertEquals(false, fflib_SObjectDomain.Test.Database.hasRecords());
+		fflib_SObjectDomain.Test.Database.onInsert(new Opportunity[] { opp } );		
+		System.assertEquals(true, fflib_SObjectDomain.Test.Database.hasRecords());
+		fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDomainConstructor.class);		
+		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());		
+		System.assertEquals('Amount exceeds your limit.', fflib_SObjectDomain.Errors.getAll()[0].message);
+		System.assertEquals(Opportunity.Amount, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
+	}	
 
 	@IsTest
 	private static void testUpdateValidationFailedWithoutDML()
@@ -67,6 +90,26 @@ private with sharing class fflib_SObjectDomainTest
 		System.assertEquals('You cannot change the Opportunity type once it has been created.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(Opportunity.Type, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
 	}
+
+	@IsTest
+	private static void testUpdateBeforeValidationFailedWithoutDML()
+	{
+		Opportunity oldOpp = (Opportunity) Opportunity.sObjectType.newSObject('006E0000006mkRQ');
+		oldOpp.Name = 'Test';
+		oldOpp.Type = 'Existing Account';
+		oldOpp.StageName = 'Qualification';
+		Opportunity newOpp = (Opportunity) Opportunity.sObjectType.newSObject('006E0000006mkRQ'); 
+		newOpp.Name = 'Test';
+		newOpp.Type = 'Existing Account'; 
+		newOpp.StageName = 'Prospecting';
+		System.assertEquals(false, fflib_SObjectDomain.Test.Database.hasRecords());		
+		fflib_SObjectDomain.Test.Database.onUpdate(new Opportunity[] { newOpp }, new Map<Id, SObject> { newOpp.Id => oldOpp } );
+		System.assertEquals(true, fflib_SObjectDomain.Test.Database.hasRecords());				
+		fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDomainConstructor.class);		
+		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());		
+		System.assertEquals('You cannot change the Opportunity stage back to Prospecting.', fflib_SObjectDomain.Errors.getAll()[0].message);
+		System.assertEquals(Opportunity.StageName, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
+	}	
 	
 	@IsTest
 	private static void testOnBeforeDeleteWithoutDML()

--- a/fflib/src/classes/fflib_SObjectDomainTest.cls
+++ b/fflib/src/classes/fflib_SObjectDomainTest.cls
@@ -36,16 +36,6 @@ private with sharing class fflib_SObjectDomainTest
 		System.assertEquals('You must provide an Account for Opportunities for existing Customers.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(Opportunity.AccountId, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
 	}
-
-	@IsTest
-	private static void testBeforeValidationWithoutDML()
-	{
-		fflib_SObjectDomain.TestSObjectDomain opps = new fflib_SObjectDomain.TestSObjectDomain(new Opportunity[] { new Opportunity ( Name = 'Test', Amount = 2000000 ) } );
-		opps.onBeforeValidate();
-		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());		
-		System.assertEquals('Amount exceeds your limit.', fflib_SObjectDomain.Errors.getAll()[0].message);
-		System.assertEquals(Opportunity.Amount, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
-	}	
 	
 	@IsTest
 	private static void testInsertValidationFailedWithoutDML()
@@ -59,19 +49,6 @@ private with sharing class fflib_SObjectDomainTest
 		System.assertEquals('You must provide an Account for Opportunities for existing Customers.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(Opportunity.AccountId, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
 	}
-
-	@IsTest
-	private static void testInsertBeforeValidationFailedWithoutDML()
-	{
-		Opportunity opp = new Opportunity ( Name = 'Test', Amount = 2000000 );
-		System.assertEquals(false, fflib_SObjectDomain.Test.Database.hasRecords());
-		fflib_SObjectDomain.Test.Database.onInsert(new Opportunity[] { opp } );		
-		System.assertEquals(true, fflib_SObjectDomain.Test.Database.hasRecords());
-		fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDomainConstructor.class);		
-		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());		
-		System.assertEquals('Amount exceeds your limit.', fflib_SObjectDomain.Errors.getAll()[0].message);
-		System.assertEquals(Opportunity.Amount, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
-	}	
 
 	@IsTest
 	private static void testUpdateValidationFailedWithoutDML()
@@ -90,26 +67,6 @@ private with sharing class fflib_SObjectDomainTest
 		System.assertEquals('You cannot change the Opportunity type once it has been created.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(Opportunity.Type, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
 	}
-
-	@IsTest
-	private static void testUpdateBeforeValidationFailedWithoutDML()
-	{
-		Opportunity oldOpp = (Opportunity) Opportunity.sObjectType.newSObject('006E0000006mkRQ');
-		oldOpp.Name = 'Test';
-		oldOpp.Type = 'Existing Account';
-		oldOpp.StageName = 'Qualification';
-		Opportunity newOpp = (Opportunity) Opportunity.sObjectType.newSObject('006E0000006mkRQ'); 
-		newOpp.Name = 'Test';
-		newOpp.Type = 'Existing Account'; 
-		newOpp.StageName = 'Prospecting';
-		System.assertEquals(false, fflib_SObjectDomain.Test.Database.hasRecords());		
-		fflib_SObjectDomain.Test.Database.onUpdate(new Opportunity[] { newOpp }, new Map<Id, SObject> { newOpp.Id => oldOpp } );
-		System.assertEquals(true, fflib_SObjectDomain.Test.Database.hasRecords());				
-		fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDomainConstructor.class);		
-		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());		
-		System.assertEquals('You cannot change the Opportunity stage back to Prospecting.', fflib_SObjectDomain.Errors.getAll()[0].message);
-		System.assertEquals(Opportunity.StageName, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
-	}	
 	
 	@IsTest
 	private static void testOnBeforeDeleteWithoutDML()


### PR DESCRIPTION
Debated on where in the base handleBeforeInsert/Update methods to call the new onBeforeValidation.  SFDC runs validations against layout, etc. before trigger and then again after before trigger (I think this is the way it works based on my reading).  There is something to be said for having onBeforeValidation occur as the first thing in onBeforeIns/Upd, something to be said for having it occur last and something to be said for having it occur first and last.  

For the PR, I decided to keep it simple and initiate as the first action.  With the handleXXX methods now marked virtual, the order can be customized by derived class if necessary.

Interested in your thoughts on where the before validation should fire in the sequence.