### PR TITLE
Rollup FF internal updates to QueryFactory

### DIFF
--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -25,7 +25,7 @@
 **/
 
 /**
- * QueryFactor provides an object-oriented way of building SOQL queries without resorting to string manipulation.
+ * QueryFactory provides an object-oriented way of building SOQL queries without resorting to string manipulation.
  * This class is not meant to be used as a replacement for all SOQL queries, and due to the relativley high overhead in both CPU and describe calls 
  * should be used in places where highly dynamic queries, such as those that include field sets or are mutated heavilly
  * in multiple locations are a good fit for use with fflib_QueryFactory.
@@ -36,10 +36,10 @@
  * Currently the WHERE clause of the query is manipulated as a single string, and is decidedly less OO-styled than other methods.
  * This is expected to be expanded upon in the future.
  * 
- * To include one or more sort expression(s), use one of the addOrdering methods.  If not specified, the "NULLS FIRST" keywords
- * will be included by default. 
+ * To include one or more ORDER BY clause(s), use one of the addOrdering methods.  If not specified, the "NULLS FIRST" keywords
+ * will be included by default. Constructing Ordering instances manually is discouraged.
  * 
- * Subselect Queries are supported with the subselectQuery method.  
+ * Subselect Queries are supported with the subselectQuery methods.  
  * More than one sub-query can be added to a single query, but sub-queries can only be 1 level deep.  
  * An exception will thrown from the subselectQuery method when there is an attempt to add a subquery to a sub-query
  * or to add a subquery to a query with an invalid relationship.
@@ -66,11 +66,6 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	private Integer limitCount;
 	private Integer offset;
 	private List<Ordering> order;
-	/**
-	 * each item in sortExpressions contains the field and the direction (ascending or descending)
-	 * use the addOrdering method to add fields to sort by.  the sort fields
-	 * appear in the SOQL query in the order they are added to the query.
-	**/ 
 	/**
 	/* Integrate checking for READ Field Level Security within the selectField(s) methods
 	/* This can optionally be enforced (or not) by calling the setEnforceFLS method prior to calling 
@@ -327,22 +322,72 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	/**
 	 * Add a subquery query to this query.  If a subquery for this relationship already exists, it will be returned.
 	 * If not, a new one will be created and returned.
+	 * @deprecated  Replaced by {@link #subselectQuery(String relationshipName)} and {@link #subselectQuery(ChildRelationship relationship)}
 	 * @exception InvalidSubqueryRelationshipException If this method is called on a subselectQuery or with an invalid relationship 
 	 * @param related The related object type
 	**/
 	public fflib_QueryFactory subselectQuery(SObjectType related){ 
+		System.debug(LoggingLevel.WARN, 'fflib_QueryFactory.subselectQuery(Schema.SObjectType) is deprecated and will be removed in a future release. Use fflib_QueryFactory.subselectQuery(String) or fflib_QueryFactory.subselectQuery(ChildRelationship) instead.');
 		return setSubselectQuery(getChildRelationship(related), false);
 	}
 
 	/**
 	 * Add a subquery query to this query.  If a subquery for this relationship already exists, it will be returned.
 	 * If not, a new one will be created and returned.
+	 * @deprecated  Replaced by {@link #subselectQuery(String relationshipName, Boolean assertIsAccessible)} and {@link #subselectQuery(ChildRelationship relationship, Boolean assertIsAccessible)}
 	 * @exception InvalidSubqueryRelationshipException If this method is called on a subselectQuery or with an invalid relationship 
 	 * @param related The related object type
 	 * @param assertIsAccessible indicates whether to check if the user has access to the subquery object
 	**/
-	public fflib_QueryFactory subselectQuery(SObjectType related, Boolean assertIsAccessible){ 
+	public fflib_QueryFactory subselectQuery(SObjectType related, Boolean assertIsAccessible){
+		System.debug(LoggingLevel.WARN, 'fflib_QueryFactory.subselectQuery(Schema.SObjectType, Boolean) is deprecated and will be removed in a future release. Use fflib_QueryFactory.subselectQuery(String, Boolean) or fflib_QueryFactory.subselectQuery(ChildRelationship, Boolean) instead.'); 
 		return setSubselectQuery(getChildRelationship(related), assertIsAccessible);
+	}
+
+	/**
+	 * Add a subquery query to this query.  If a subquery for this relationshipName already exists, it will be returned.
+	 * If not, a new one will be created and returned.
+	 * @exception InvalidSubqueryRelationshipException If this method is called on a subselectQuery or with an invalid relationship 
+	 * @param relationshipName The relationshipName to be added as a subquery
+	**/
+	public fflib_QueryFactory subselectQuery(String relationshipName){ 
+		return subselectQuery(relationshipName, false);
+	}
+
+	/**
+	 * Add a subquery query to this query.  If a subquery for this relationship already exists, it will be returned.
+	 * If not, a new one will be created and returned.
+	 * @exception InvalidSubqueryRelationshipException If this method is called on a subselectQuery or with an invalid relationship 
+	 * @param relationshipName The relationshipName to be added as a subquery
+	 * @param assertIsAccessible indicates whether to check if the user has access to the subquery object
+	**/
+	public fflib_QueryFactory subselectQuery(String relationshipName, Boolean assertIsAccessible){
+		ChildRelationship relationship = getChildRelationship(relationshipName);
+		if (relationship != null) {
+			return setSubselectQuery(relationship, assertIsAccessible);
+		}
+		throw new InvalidSubqueryRelationshipException('Invalid call to subselectQuery with relationshipName = '+relationshipName +'.  Relationship does not exist for ' + table.getDescribe().getName());	
+	}
+
+	/**
+	 * Add a subquery query to this query.  If a subquery for this relationshipName already exists, it will be returned.
+	 * If not, a new one will be created and returned.
+	 * @exception InvalidSubqueryRelationshipException If this method is called on a subselectQuery or with an invalid relationship 
+	 * @param relationship The ChildRelationship to be added as a subquery
+	**/
+	public fflib_QueryFactory subselectQuery(ChildRelationship relationship){ 
+		return subselectQuery(relationship, false);
+	}
+
+	/**
+	 * Add a subquery query to this query.  If a subquery for this relationship already exists, it will be returned.
+	 * If not, a new one will be created and returned.
+	 * @exception InvalidSubqueryRelationshipException If this method is called on a subselectQuery or with an invalid relationship 
+	 * @param relationship The ChildRelationship to be added as a subquery
+	 * @param assertIsAccessible indicates whether to check if the user has access to the subquery object
+	**/
+	public fflib_QueryFactory subselectQuery(ChildRelationship relationship, Boolean assertIsAccessible){
+		return setSubselectQuery(relationship, assertIsAccessible);
 	}
 
 	/**
@@ -391,6 +436,19 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
             }   
         }
         throw new InvalidSubqueryRelationshipException('Invalid call to subselectQuery.  Invalid relationship for table '+table + ' and objtype='+objType);
+    }
+
+	/**
+	 * Get the ChildRelationship from the Table for the relationship name passed in.
+	 * @param relationshipName The name of the object's ChildRelationship on get
+	**/
+ 	private Schema.ChildRelationship getChildRelationship(String relationshipName){
+        for (Schema.ChildRelationship childRow : table.getDescribe().getChildRelationships()){
+            if (childRow.getRelationshipName() == relationshipName){ 
+                return childRow;
+            }   
+        }
+        return null;
     }
 
 	/**
@@ -503,6 +561,33 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		if(limitCount != null)
 			result += ' LIMIT '+limitCount;
 		return result;
+	}
+
+	/**
+	 * Create a "deep" clone of this object that can be safely mutated without affecting the cloned instance
+	 * @return a deep clone of this fflib_QueryFactory
+	**/
+	public fflib_QueryFactory deepClone(){	
+
+		fflib_QueryFactory clone = new fflib_QueryFactory(this.table)
+			.setLimit(this.limitCount)
+			.setCondition(this.conditionExpression)
+			.setEnforceFLS(this.enforceFLS);
+
+		Map<Schema.ChildRelationship, fflib_QueryFactory> subqueries = this.subselectQueryMap;
+		if(subqueries != null) {
+			Map<Schema.ChildRelationship, fflib_QueryFactory> clonedSubqueries = new Map<Schema.ChildRelationship, fflib_QueryFactory>();
+			for(Schema.ChildRelationship key : subqueries.keySet()) {
+				clonedSubqueries.put(key, subqueries.get(key).deepClone());
+			}
+			clone.subselectQueryMap = clonedSubqueries;
+		}
+
+		clone.relationship = this.relationship;
+		clone.order = this.order.clone();
+		clone.fields = this.fields.clone();
+
+		return clone;
 	}
 	
 	public class Ordering{

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -26,6 +26,17 @@
 
 @isTest
 private class fflib_QueryFactoryTest {
+
+	@isTest
+	static void fieldSelections(){
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField('firstName');
+		qf.selectField(Schema.Contact.SObjectType.fields.lastName);
+		qf.selectFields( new Set<String>{'acCounTId', 'account.name'} );
+		qf.selectFields( new List<String>{'homePhonE','fAX'} );
+		qf.selectFields( new List<Schema.SObjectField>{ Contact.Email, Contact.Title } );
+	}
+
 	@isTest
 	static void simpleFieldSelection() {
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
@@ -36,16 +47,6 @@ private class fflib_QueryFactoryTest {
 		qf.setLimit(100);
 		System.assertEquals(100,qf.getLimit());
 		System.assert( qf.toSOQL().endsWithIgnoreCase('LIMIT '+qf.getLimit()), 'Failed to respect limit clause:'+qf.toSOQL() );
-	}
-
-	@isTest
-	static void fieldSelections(){
-		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
-		qf.selectField('firstName');
-		qf.selectField(Schema.Contact.SObjectType.fields.lastName);
-		qf.selectFields( new Set<String>{'acCounTId', 'account.name'} );
-		qf.selectFields( new List<String>{'homePhonE','fAX'} );
-		qf.selectFields( new List<Schema.SObjectField>{ Contact.Email, Contact.Title } );
 	}
 
 	@isTest
@@ -254,6 +255,167 @@ private class fflib_QueryFactoryTest {
 		fflib_QueryFactory.QueryField qfld = new fflib_QueryFactory.QueryField(new List<Schema.SObjectField>{
 			Schema.Contact.SObjectType.fields.AccountId});
 		System.assert(!qfld.equals(new Contact()));	
+	}
+
+	@isTest
+	static void addChildQueriesWithChildRelationship_success(){
+		Account acct = new Account();
+		acct.Name = 'testchildqueriesacct';
+		insert acct;
+		Contact cont = new Contact();
+		cont.FirstName = 'test';
+		cont.LastName = 'test';
+		cont.AccountId = acct.Id;
+		insert cont;
+        Task tsk = new Task();
+        tsk.WhoId = cont.Id;
+        tsk.Subject = 'test';
+        tsk.ActivityDate = System.today();
+        insert tsk;
+
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField('name').selectField('Id').setCondition( 'name like \'%test%\'' ).addOrdering('CreatedDate',fflib_QueryFactory.SortOrder.DESCENDING, true);
+		Schema.DescribeSObjectResult descResult = Contact.SObjectType.getDescribe();
+		//explicitly assert object accessibility when creating the subselect
+		qf.subselectQuery('Tasks', true).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
+		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
+		System.assert(queries != null);
+		List<Contact> contacts = Database.query(qf.toSOQL());
+		System.assert(contacts != null && contacts.size() == 1);
+		System.assert(contacts[0].Tasks.size() == 1);
+		System.assert(contacts[0].Tasks[0].Subject == 'test');
+	}
+
+	@isTest
+	static void addChildQueriesWithChildRelationshipNoAccessibleCheck_success(){
+		Account acct = new Account();
+		acct.Name = 'testchildqueriesacct';
+		insert acct;
+		Contact cont = new Contact();
+		cont.FirstName = 'test';
+		cont.LastName = 'test';
+		cont.AccountId = acct.Id;
+		insert cont;
+        Task tsk = new Task();
+        tsk.WhoId = cont.Id;
+        tsk.Subject = 'test';
+        tsk.ActivityDate = System.today();
+        insert tsk;
+
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField('name').selectField('Id').setCondition( 'name like \'%test%\'' ).addOrdering('CreatedDate',fflib_QueryFactory.SortOrder.DESCENDING, true);
+		//explicitly assert object accessibility when creating the subselect
+		qf.subselectQuery('Tasks').selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
+		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
+		System.assert(queries != null);
+		List<Contact> contacts = Database.query(qf.toSOQL());
+		System.assert(contacts != null && contacts.size() == 1);
+		System.assert(contacts[0].Tasks.size() == 1);
+		System.assert(contacts[0].Tasks[0].Subject == 'test');
+	}
+
+	@isTest
+	static void addChildQueriesWithChildRelationshipObjCheckIsAccessible_success(){
+		Account acct = new Account();
+		acct.Name = 'testchildqueriesacct';
+		insert acct;
+		Contact cont = new Contact();
+		cont.FirstName = 'test';
+		cont.LastName = 'test';
+		cont.AccountId = acct.Id;
+		insert cont;
+        Task tsk = new Task();
+        tsk.WhoId = cont.Id;
+        tsk.Subject = 'test';
+        tsk.ActivityDate = System.today();
+        insert tsk;
+
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField('name').selectField('Id').setCondition( 'name like \'%test%\'' ).addOrdering('CreatedDate',fflib_QueryFactory.SortOrder.DESCENDING, true);
+		Schema.DescribeSObjectResult descResult = Contact.SObjectType.getDescribe();
+		Schema.ChildRelationship relationship;
+		for (Schema.ChildRelationship childRow : descResult.getChildRelationships()){
+        	//occasionally on some standard objects (Like Contact child of Contact) do not have a relationship name.  
+        	//if there is no relationship name, we cannot query on it, so throw an exception.
+            if (childRow.getRelationshipName() == 'Tasks'){ 
+                relationship = childRow;
+            }   
+        }
+       	//explicitly assert object accessibility when creating the subselect
+		qf.subselectQuery(relationship, true).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
+		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
+		System.assert(queries != null);
+		List<Contact> contacts = Database.query(qf.toSOQL());
+		System.assert(contacts != null && contacts.size() == 1);
+		System.assert(contacts[0].Tasks.size() == 1);
+		System.assert(contacts[0].Tasks[0].Subject == 'test');
+	}
+
+	@isTest
+	static void addChildQueriesWithChildRelationshipObj_success(){
+		Account acct = new Account();
+		acct.Name = 'testchildqueriesacct';
+		insert acct;
+		Contact cont = new Contact();
+		cont.FirstName = 'test';
+		cont.LastName = 'test';
+		cont.AccountId = acct.Id;
+		insert cont;
+        Task tsk = new Task();
+        tsk.WhoId = cont.Id;
+        tsk.Subject = 'test';
+        tsk.ActivityDate = System.today();
+        insert tsk;
+
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField('name').selectField('Id').setCondition( 'name like \'%test%\'' ).addOrdering('CreatedDate',fflib_QueryFactory.SortOrder.DESCENDING, true);
+		Schema.DescribeSObjectResult descResult = Contact.SObjectType.getDescribe();
+		Schema.ChildRelationship relationship;
+		for (Schema.ChildRelationship childRow : descResult.getChildRelationships()){
+        	//occasionally on some standard objects (Like Contact child of Contact) do not have a relationship name.  
+        	//if there is no relationship name, we cannot query on it, so throw an exception.
+            if (childRow.getRelationshipName() == 'Tasks'){ 
+                relationship = childRow;
+            }   
+        }
+       	//explicitly assert object accessibility when creating the subselect
+		qf.subselectQuery(relationship).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
+		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
+		System.assert(queries != null);
+		List<Contact> contacts = Database.query(qf.toSOQL());
+		System.assert(contacts != null && contacts.size() == 1);
+		System.assert(contacts[0].Tasks.size() == 1);
+		System.assert(contacts[0].Tasks[0].Subject == 'test');
+	}
+
+	@isTest
+	static void addChildQueriesWithChildRelationshipNoAccessibleCheck_fail(){
+		Account acct = new Account();
+		acct.Name = 'testchildqueriesacct';
+		insert acct;
+		Contact cont = new Contact();
+		cont.FirstName = 'test';
+		cont.LastName = 'test';
+		cont.AccountId = acct.Id;
+		insert cont;
+        Task tsk = new Task();
+        tsk.WhoId = cont.Id;
+        tsk.Subject = 'test';
+        tsk.ActivityDate = System.today();
+        insert tsk;
+
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField('name').selectField('Id').setCondition( 'name like \'%test%\'' ).addOrdering('CreatedDate',fflib_QueryFactory.SortOrder.DESCENDING, true);
+		Schema.DescribeSObjectResult descResult = Contact.SObjectType.getDescribe();
+		//explicitly assert object accessibility when creating the subselect
+		//
+		Exception e;
+		try {
+			qf.subselectQuery('Tas').selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
+		} catch (fflib_QueryFactory.InvalidSubqueryRelationshipException ex) {
+			e = ex;   
+		}	
+		System.assertNotEquals(e, null);
 	}
 
 	@isTest
@@ -502,6 +664,115 @@ private class fflib_QueryFactoryTest {
 		System.assertEquals(qf1.toSOQL(), qf2.toSOQL());
 		System.assertEquals(expectedQuery, qf1.toSOQL());
 		System.assertEquals(expectedQuery, qf2.toSOQL());
+	}
+
+	@isTest
+	static void deepCloneBasicNoChanges() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType)	
+		.setLimit(10)
+		.setCondition('id=12345')
+		.selectField('Description')
+		.addOrdering(new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) )
+		.addOrdering( new fflib_QueryFactory.Ordering('Contact','CreatedDATE',fflib_QueryFactory.SortOrder.DESCENDING))
+		.setEnforceFLS(true);
+
+		fflib_QueryFactory qf2 = qf.deepClone();
+
+		System.assertEquals(qf2, qf);
+
+		System.assertEquals(qf.getLimit(), qf2.getLimit());
+		System.assertEquals(qf.getCondition(), qf2.getCondition());
+		System.assertEquals(qf.toSOQL(), qf2.toSOQL());
+		System.assertEquals(qf.getOrderings(), qf2.getOrderings());
+	}
+
+	@isTest
+	static void deepCloneSubqueryNoChanges() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType)	
+		.setLimit(10)
+		.setCondition('id=12345')
+		.selectField('Description')
+		.addOrdering(new fflib_QueryFactory.Ordering('Account','Name',fflib_QueryFactory.SortOrder.ASCENDING) )
+		.addOrdering( new fflib_QueryFactory.Ordering('Account','Description',fflib_QueryFactory.SortOrder.DESCENDING))
+		.setEnforceFLS(true);
+
+		qf.subselectQuery('Contacts', true);	
+
+		fflib_QueryFactory qf2 = qf.deepClone();
+
+		System.assertEquals(qf, qf2);
+
+		System.assertEquals(qf.getLimit(), qf2.getLimit());
+		System.assertEquals(qf.getCondition(), qf2.getCondition());
+		System.assertEquals(qf.toSOQL(), qf2.toSOQL());
+		System.assertEquals(qf.getOrderings(), qf2.getOrderings());
+		System.assertEquals(qf.getSubselectQueries(), qf2.getSubselectQueries());
+	}
+
+	@isTest
+	static void deepCloneBasic() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType)	
+		.setLimit(10)
+		.setCondition('id=12345')
+		.selectField('Description')
+		.addOrdering(new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) )
+		.addOrdering( new fflib_QueryFactory.Ordering('Contact','CreatedDATE',fflib_QueryFactory.SortOrder.DESCENDING))
+		.setEnforceFLS(true);
+
+
+		fflib_QueryFactory qf2 = qf.deepClone()
+			.setLimit(200)
+			.setCondition('id=54321')
+			.selectField('Fax')
+			.addOrdering( new fflib_QueryFactory.Ordering('Contact','Fax',fflib_QueryFactory.SortOrder.ASCENDING))
+			.setEnforceFLS(false);
+
+		qf2.getOrderings().remove(0);
+
+		System.assertEquals(10, qf.getLimit());
+		System.assertEquals(200, qf2.getLimit());
+
+		System.assertEquals('id=12345', qf.getCondition());
+		System.assertEquals('id=54321', qf2.getCondition());
+
+		String query = qf.toSOQL();
+		String query2 = qf2.toSOQL();
+
+		System.assert(query.containsIgnoreCase('Fax') == false);
+		System.assert(query.containsIgnoreCase('Description'));
+		System.assert(query2.containsIgnoreCase('Description'));
+		System.assert(query2.containsIgnoreCase('Fax'));
+
+		System.assertEquals(2, qf.getOrderings().size());
+		System.assertEquals(Contact.name, qf.getOrderings()[0].getField() );
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[1].getDirection());
+
+		System.assertEquals(2, qf2.getOrderings().size());
+		System.assertEquals(Contact.Fax, qf2.getOrderings()[1].getField());
+		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf2.getOrderings()[1].getDirection());
+
+	}
+
+	@isTest
+	static void deepCloneSubquery() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);
+		qf.subselectQuery('Contacts', true);
+
+		fflib_QueryFactory qf2 = qf.deepClone();
+		qf2.subselectQuery('Opportunities', true);
+
+		List<fflib_QueryFactory> subqueries = qf.getSubselectQueries();
+		List<fflib_QueryFactory> subqueries2 = qf2.getSubselectQueries();
+
+		fflib_QueryFactory subquery2_0 = subqueries2.get(0);
+
+		subquery2_0.addOrdering(new fflib_QueryFactory.Ordering('Contact','Name',fflib_QueryFactory.SortOrder.ASCENDING));
+
+		System.assert(subqueries.size() == 1);
+		System.assert(subqueries2.size() == 2);
+
+		System.assert(qf.getSubselectQueries().get(0).getOrderings().size() == 0);
+		System.assert(qf2.getSubselectQueries().get(0).getOrderings().size() == 1);
 	}
 
 	public static User createTestUser_noAccess(){

--- a/fflib/src/classes/fflib_SObjectDescribe.cls
+++ b/fflib/src/classes/fflib_SObjectDescribe.cls
@@ -182,6 +182,8 @@ public class fflib_SObjectDescribe {
 		set;
 	}
 	public static fflib_SObjectDescribe getDescribe(String sObjectName){
+		if(String.isBlank(sObjectName))
+			return null;
 		fflib_SObjectDescribe result = instanceCache.get(sObjectName.toLowerCase());
 		if(result == null){
 			Schema.SObjectType token = wrappedGlobalDescribe.get(sObjectName.toLowerCase());
@@ -193,18 +195,24 @@ public class fflib_SObjectDescribe {
 		return result;
 	}
 	public static fflib_SObjectDescribe getDescribe(Schema.SObjectType token){
+		if(token == null)
+			return null;
 		fflib_SObjectDescribe result = instanceCache.get(String.valueOf(token).toLowerCase());
 		if(result == null)
 			result = new fflib_SObjectDescribe(token);		
 		return result;
 	}
 	public static fflib_SObjectDescribe getDescribe(Schema.DescribeSObjectResult nativeDescribe){
+		if(nativeDescribe == null)
+			return null;
 		fflib_SObjectDescribe result = instanceCache.get(nativeDescribe.getName().toLowerCase());
 		if(result == null)
 			result = new fflib_SObjectDescribe(nativeDescribe.getSobjectType());		
 		return result;
 	}
 	public static fflib_SObjectDescribe getDescribe(SObject instance){
+		if(instance == null)
+			return null;
 		return getDescribe(instance.getSobjectType());
 	}
 
@@ -255,11 +263,13 @@ public class fflib_SObjectDescribe {
 		 *  
 		**/
 		protected virtual Object getObject(String name, Boolean implyNamespace){
+			if(name == null) //short-circuit lookup logic since null can't possibly be a valid field name, and it saves us null checking
+				return null;
 			String preferredValue = ((implyNamespace ? currentNamespace+'__' : '') + name).toLowerCase();
 			if(values.containsKey(preferredValue)){
 				return values.get(preferredValue);
 			}else if(implyNamespace){
-				return values.get(name);
+				return values.get(name.toLowerCase());
 			}else{
 				return null;
 			}
@@ -268,17 +278,36 @@ public class fflib_SObjectDescribe {
 			return this.containsKey(name, true);
 		}
 		public virtual Boolean containsKey(String name, Boolean implyNamespace){
+			if(name == null) //short-circuit lookup logic since null can't possibly be a valid field name, and it saves us null checking
+				return null;
 			String preferredValue = ((implyNamespace ? currentNamespace+'__' : '') + name).toLowerCase();
 			return (
 				values.containsKey(preferredValue) ||
-				implyNamespace && values.containsKey(name)
+				implyNamespace && values.containsKey(name.toLowerCase())
 			);
 		}
 		public virtual Integer size(){
 			return values.size();
 		}
+		/**
+		 * Returns the key set of the map.
+		 * Note: unlike other NamespacedAttributeMap methods keySet defaults implyNamespace to false if not specified.
+		**/
 		public virtual Set<String> keySet(){
-			return values.keySet();
+			return this.keySet(false);
+		}
+		public virtual Set<String> keySet(Boolean implyNamespace){
+			if(implyNamespace){
+				Set<String> result = new Set<String>();
+				for(String key:values.keySet()){
+					result.add(
+						key.removeStartIgnoreCase(currentNamespace+'__')
+					);
+				}
+				return result;
+			}else{
+				return values.keySet();
+			}
 		}
 	}
 

--- a/fflib/src/classes/fflib_SObjectDescribeTest.cls
+++ b/fflib/src/classes/fflib_SObjectDescribeTest.cls
@@ -30,7 +30,25 @@
 **/
 @isTest
 private class fflib_SObjectDescribeTest {
-	
+
+	/**
+	 * Verify that the different ways of getting your hands on an fflib_SObjectDescribe instance all handle null inputs
+	 * (and blank/empty strings, why not?) by returning null - since there's no possible way to resolve it.
+	**/
+	@isTest
+	static void getDescribe_badInput(){
+		String nullStr = null; //having it as a string var makes for unambiguous selection of overloads
+		Schema.SObjectType nullType = null;
+		Schema.DescribeSObjectResult nullDescribe = null;
+		SObject nullSObject = null;
+		System.assertEquals(null, fflib_SObjectDescribe.getDescribe(nullStr));
+		System.assertEquals(null, fflib_SObjectDescribe.getDescribe(''));
+		System.assertEquals(null, fflib_SObjectDescribe.getDescribe(' '));
+		System.assertEquals(null, fflib_SObjectDescribe.getDescribe(nullType));
+		System.assertEquals(null, fflib_SObjectDescribe.getDescribe(nullDescribe));
+		System.assertEquals(null, fflib_SObjectDescribe.getDescribe(nullSObject));
+	}
+
 	@isTest
 	static void NamespacedAttributeMap_implementations(){
 		fflib_SObjectDescribe.GlobalDescribeMap gdm = fflib_SObjectDescribe.getGlobalDescribe();
@@ -44,24 +62,34 @@ private class fflib_SObjectDescribeTest {
 
 		System.assertEquals(fields.get('name'), Account.SObjectType.fields.name); //behavior of FieldsMap is tested in another method
 		System.assertEquals(Schema.SObjectType.Account.fields.getMap().size(), fields.size());
+
+		System.assertEquals(null, fields.get(null), 'Null input should result in null ouput.');
+		System.assertEquals(null, fields.get(''), 'Invalid fieldname input should result in null ouput.');
 	}
 
 	@isTest
 	static void FieldsMap(){
 		String fakeNamespace = 'fflib_test';
 		Map<String,Schema.SObjectField> fakeFieldData = new Map<String,Schema.SObjectField>{
-			'name__c' => Contact.SObjectType.fields.name, //re-use stndard field types since we can't mock them
+			'name__c' => Contact.SObjectType.fields.name, //re-use standard field types since we can't mock them
 			fakeNamespace+'__name__c' => Account.SObjectType.fields.name,
+			fakeNamespace+'__otherField__c' => Account.SObjectType.fields.name,
 			'createddate' => Contact.SObjectType.fields.CreatedDate
 		};
 		fflib_SObjectDescribe.FieldsMap fields = new fflib_SObjectDescribe.FieldsMap(fakeFieldData);
 		fields.currentNamespace = fakeNamespace;
 		System.assertEquals(true, fields.containsKey('name__c') );
-		System.assertEquals(true, fields.containsKey(fakeNamespace+'__name__c') );
-		System.assert(fields.get('name__c') === fields.get(fakeNamespace+'__name__c'));
+		System.assertEquals(true, fields.containsKey(fakeNamespace.toUpperCase()+'__nAMe__c') );
+		System.assert(fields.get('NAme__c') === fields.get(fakeNamespace+'__namE__c'));
+
+		System.assert(!fields.keySet(false).contains('otherField__c'));
+		System.assert(fields.keySet(false).contains(fakeNamespace+'__otherField__c'));
+
+		System.assert(fields.keySet(true).contains('otherField__c'));
+		System.assert(!fields.keySet(true).contains(fakeNamespace+'__otherField__c'));
 
 		fields.currentNamespace = 'someOtherNamespace';
-		System.assertNotEquals(fields.get('name__c'), fields.get(fakeNamespace+'__name__c'));
+		System.assertNotEquals(fields.get('name__C'), fields.get(fakeNamespace.capitalize()+'__nAme__c'));
 	}
 
 	@isTest
@@ -81,7 +109,7 @@ private class fflib_SObjectDescribeTest {
 		gdm.currentNamespace = 'someOtherNamespace';
 		System.assertNotEquals(gdm.get('name__c'), gdm.get(fakeNamespace+'__name__c'));
 	}
-	
+
 	@isTest //Tests all forms of the getDescribe static
 	static void getAccountDescribes(){
 		fflib_SObjectDescribe d = fflib_SObjectDescribe.getDescribe('Account');
@@ -98,23 +126,40 @@ private class fflib_SObjectDescribeTest {
 		for(integer i = 0; i < 10; i++){
 			fields = d.getFieldsMap();
 		}
+
+		// Describe Limits removed since Summer ’14.
+		// https://developer.salesforce.com/releases/release/Summer14/New+Apex+Enhancements
+
+		// Because describe limits are no longer enforced in any API version, this method is no longer available.
+		// In API version 30.0 and earlier, this method is available but is deprecated.
+
+		// System.assertEquals(1, Limits.getFieldsDescribes() );
+
 		System.assertEquals(false,fields.isEmpty());
+		System.assertEquals(Account.SObjectType, d.getSObjectType());
 	}
 
 	@isTest
-	static void simpleAccountFieldSetDescribe(){ 
+	static void simpleAccountFieldSetDescribe(){
 		fflib_SObjectDescribe d = fflib_SObjectDescribe.getDescribe(Account.SObjectType);
 		Map<String,Schema.FieldSet> fields;
 		for(integer i = 0; i < 10; i++){
 			fields = d.getFieldSetsMap();
 		}
-		
-		// We need to assert something here... but what?
-		//no asserts on result size to avoid a requirement on field sets existing
+
+		// Describe Limits removed since Summer ’14.
+		// https://developer.salesforce.com/releases/release/Summer14/New+Apex+Enhancements
+
+		// Because describe limits are no longer enforced in any API version, this method is no longer available.
+		// In API version 30.0 and earlier, this method is available but is deprecated.
+
+		// System.assertEquals(1, Limits.getFieldSetsDescribes() );
+
+		// no asserts on result size to avoid a requirement on field sets existing
 	}
-	
+
 	@isTest
-	static void simpleAccountGetNameField(){
+    	static void simpleAccountGetNameField(){
         	fflib_SObjectDescribe d = fflib_SObjectDescribe.getDescribe(Account.SObjectType);
         	Schema.SObjectField nameField = d.getNameField();
         	System.assertEquals('Name', nameField.getDescribe().getName());


### PR DESCRIPTION
Deprecates creating `fflib_QueryFactory` subselects by related SObject's type. Fragile as it's non-deterministic once you have more than one relationship to that type.

Replaces it with new subselect creation methods that are safe as you extend your schema.
Adds the ability to do a deep clone of a `fflib_QueryFactory` instance.