### PR TITLE
Added base class for TestDataBuilders

### DIFF
--- a/fflib/src/classes/fflib_DomainObjectBuilder.cls
+++ b/fflib/src/classes/fflib_DomainObjectBuilder.cls
@@ -1,0 +1,106 @@
+public virtual class fflib_DomainObjectBuilder {
+    
+    public SObject record;
+
+    private Map<Schema.SObjectField, fflib_DomainObjectBuilder> parentByRelationship = new Map<Schema.SObjectField, fflib_DomainObjectBuilder>();
+    
+    private static fflib_SObjectUnitOfWork uow = initUnitOfWork();
+    private static Set<fflib_DomainObjectBuilder> objects = new Set<fflib_DomainObjectBuilder>();
+    
+    
+    // CONSTRUCTORS
+
+    public fflib_DomainObjectBuilder(SObjectType type) {
+        this.record = type.newSObject(null, true);
+        
+        objects.add(this);
+    }
+    
+    
+    public fflib_DomainObjectBuilder(SObjectType type, Schema.SObjectField parentRelationship, fflib_DomainObjectBuilder parent) {
+        this(type);
+        
+        setParent(parentRelationship, parent);
+    }
+    
+    
+    public fflib_DomainObjectBuilder(SObjectType type,
+                        Schema.SObjectField leftRelationship, fflib_DomainObjectBuilder left,
+                        Schema.SObjectField rightRelationship, fflib_DomainObjectBuilder right) {
+        this(type);
+        
+        setParent(leftRelationship, left);
+        setParent(rightRelationship, right);
+    }
+    
+    
+    // PUBLIC METHODS
+    
+    public SObject build() {
+        for(fflib_DomainObjectBuilder obj: objects) {
+            uow.registerNew(obj.record);
+            
+            for(Schema.SObjectField rel: obj.parentByRelationship.keySet()) {
+                fflib_DomainObjectBuilder parent = obj.parentByRelationship.get(rel);
+                uow.registerRelationship(obj.record, rel, parent.record);
+            }
+        }
+
+        uow.commitWork();
+        
+        uow = initUnitOfWork();
+        objects.clear();
+        
+        return record;
+    }
+    
+    
+    // PROTECTED METHODS
+    
+    protected fflib_DomainObjectBuilder setParent(Schema.SObjectField parentRelationship, fflib_DomainObjectBuilder parent) {
+        
+        // Note: The parent registered last always wins!
+        fflib_DomainObjectBuilder oldParent = parentByRelationship.get(parentRelationship);
+        
+        if(oldParent != null) {
+            oldParent.clearTree();
+        }
+        
+        parentByRelationship.put(parentRelationship, parent);
+        
+        // Note: Return parent instead of this as we call this always from the parent
+        return parent;
+    }
+    
+    
+    protected fflib_DomainObjectBuilder set(String fieldName, Object value) {
+        record.put(fieldName, value);
+        return this;
+    }
+    
+    
+    protected fflib_DomainObjectBuilder set(Schema.SObjectField field, Object value) {
+        record.put(field, value);
+        return this;
+    }
+
+    
+    // PRIVATE METHODS
+    
+    private void clearTree() {
+        for(fflib_DomainObjectBuilder obj : parentByRelationship.values()) {
+            obj.clearTree();
+        }
+        
+        objects.remove(this);
+    }
+    
+    
+    private static fflib_SObjectUnitOfWork initUnitOfWork() {
+        return new fflib_SObjectUnitOfWork(new List<SObjectType> { 
+                                                    Opportunity.SObjectType,
+                                                    Product2.SObjectType,
+                                                    PriceBookEntry.SObjectType,
+                                                    OpportunityLineItem.SObjectType });
+    }
+}

--- a/fflib/src/classes/fflib_DomainObjectBuilder.cls
+++ b/fflib/src/classes/fflib_DomainObjectBuilder.cls
@@ -1,45 +1,70 @@
-public virtual class fflib_DomainObjectBuilder {
-    
+/**
+ * This class ports the TestDataBuilder pattern (http://www.natpryce.com/articles/000714.html) invented by Nat Pryce (http://www.natpryce.com/)
+ * to the world of Apex and Salesforce.com.
+ *
+ * While test data in unit tests should be as simple as possible and could even be mocked with frameworks like ApexMock,
+ * complex enterprise software also needs integration tests.The TestDataBuilder pattern reduces complexity,
+ * eliminates redundancy and improves readability while setting up complex test data structures for such tests.
+ *
+ * Learn how to replace your redundant, error-prone and test-specific helper classes with a set of small domain classes
+ * and how to write super-readable test by checking the sample code in fflib-apex-common-samplecode/blob/master/fflib-sample-code/src/classes/InvoicingServiceTest.cls
+ */
+ public virtual class fflib_DomainObjectBuilder {
+
     public SObject record;
 
     private Map<Schema.SObjectField, fflib_DomainObjectBuilder> parentByRelationship = new Map<Schema.SObjectField, fflib_DomainObjectBuilder>();
-    
+
     private static fflib_SObjectUnitOfWork uow = initUnitOfWork();
     private static Set<fflib_DomainObjectBuilder> objects = new Set<fflib_DomainObjectBuilder>();
-    
-    
+
+
     // CONSTRUCTORS
 
+    /**
+     * Constructs a standalone Domain object
+     */
     public fflib_DomainObjectBuilder(SObjectType type) {
         this.record = type.newSObject(null, true);
-        
+
         objects.add(this);
     }
-    
-    
+
+    /**
+     * Constructs a child/dependent Domain object
+     */
     public fflib_DomainObjectBuilder(SObjectType type, Schema.SObjectField parentRelationship, fflib_DomainObjectBuilder parent) {
         this(type);
-        
+
         setParent(parentRelationship, parent);
     }
-    
-    
+
+    /**
+     * Constructs a linker Domain object
+     */
     public fflib_DomainObjectBuilder(SObjectType type,
                         Schema.SObjectField leftRelationship, fflib_DomainObjectBuilder left,
                         Schema.SObjectField rightRelationship, fflib_DomainObjectBuilder right) {
         this(type);
-        
+
         setParent(leftRelationship, left);
         setParent(rightRelationship, right);
     }
-    
-    
+
+
     // PUBLIC METHODS
-    
+
+    /**
+     * Build method as defined by the TestDataBuilder pattern. Call this method on
+     * any of the Domain objects created in your test method and everything created
+     * in memory will be inserted.
+     * The later you call it the fewer DMLs your test does consume. As single call is enough
+     * but you can also call it multiple times to simulate multiple DML operations in your tests.
+     */
     public SObject build() {
         for(fflib_DomainObjectBuilder obj: objects) {
             uow.registerNew(obj.record);
-            
+
             for(Schema.SObjectField rel: obj.parentByRelationship.keySet()) {
                 fflib_DomainObjectBuilder parent = obj.parentByRelationship.get(rel);
                 uow.registerRelationship(obj.record, rel, parent.record);
@@ -47,57 +72,57 @@ public virtual class fflib_DomainObjectBuilder {
         }
 
         uow.commitWork();
-        
+
         uow = initUnitOfWork();
         objects.clear();
-        
+
         return record;
     }
-    
-    
+
+
     // PROTECTED METHODS
-    
+
     protected fflib_DomainObjectBuilder setParent(Schema.SObjectField parentRelationship, fflib_DomainObjectBuilder parent) {
-        
+
         // Note: The parent registered last always wins!
         fflib_DomainObjectBuilder oldParent = parentByRelationship.get(parentRelationship);
-        
+
         if(oldParent != null) {
             oldParent.clearTree();
         }
-        
+
         parentByRelationship.put(parentRelationship, parent);
-        
+
         // Note: Return parent instead of this as we call this always from the parent
         return parent;
     }
-    
-    
+
+
     protected fflib_DomainObjectBuilder set(String fieldName, Object value) {
         record.put(fieldName, value);
         return this;
     }
-    
-    
+
+
     protected fflib_DomainObjectBuilder set(Schema.SObjectField field, Object value) {
         record.put(field, value);
         return this;
     }
 
-    
+
     // PRIVATE METHODS
-    
+
     private void clearTree() {
         for(fflib_DomainObjectBuilder obj : parentByRelationship.values()) {
             obj.clearTree();
         }
-        
+
         objects.remove(this);
     }
-    
-    
+
+
     private static fflib_SObjectUnitOfWork initUnitOfWork() {
-        return new fflib_SObjectUnitOfWork(new List<SObjectType> { 
+        return new fflib_SObjectUnitOfWork(new List<SObjectType> {
                                                     Opportunity.SObjectType,
                                                     Product2.SObjectType,
                                                     PriceBookEntry.SObjectType,

--- a/fflib/src/classes/fflib_DomainObjectBuilder.cls-meta.xml
+++ b/fflib/src/classes/fflib_DomainObjectBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>34.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
_As promised in my [Stackexchange question](http://salesforce.stackexchange.com/questions/77387/how-to-best-use-the-test-data-builder-pattern-in-a-database-context) I hereby (ask to) contribute a new Pattern called TestDataBuilder. I think it could be of high use to many library users that have complex data structures that they need to run Apex Integration tests on. I have submitted a pull request to [fflib-apex-common](https://github.com/financialforcedev/fflib-apex-common) includung a TestDataBuilder base class and another pull request to [fflib-apex-common-samplecode](https://github.com/financialforcedev/fflib-apex-common-samplecode) with sample code showing how to use it._

There is awesome support in the library for Apex unit test. They should be fast and isolated. With [ApexMocks](https://github.com/financialforcedev/fflib-apex-mocks) [both is achieved](http://andyinthecloud.com/2015/03/22/unit-testing-with-apex-enterprise-patterns-and-apexmocks-part-1/). But complex code also needs integration tests where code is execute on more complex test data. In the world of Enterprise software outside of Salesforce.com there are experts that have created patterns for flexible and readable (fluent, concise) test data generation.

Among them the most notable is [Nat Pryce](http://www.natpryce.com/) who wrote a [great book](http://www.amazon.com/Growing-Object-Oriented-Software-Guided-Tests/dp/0321503627) about testing and somewhat invented the [TestDataBuilder pattern](http://www.natpryce.com/articles/000714.html). 

Up2Go as a Salesforce.com ISV has products with huge amount of Integration test where each of them needs to build up huge "trees" of related records. Over the year we suffered from our complex and mostly redundant TestHelpers classes where each created the same object slightly different. Whenever we changed the datamodel we had to sync all the Helpers or otherwise tests would magically fail.
- By incorporating **a single short** Builder class for each test-relevant Domain SObject we could centralize all the creation knowledge and eliminating redundancy. 
- By internally leveraging the 'fflib_SObjectUnitOfWork' for the DML all **test run dramatically faster**.
- The [Fluent API](https://en.wikipedia.org/wiki/Fluent_interface) style of the Builder pattern combined with having all the database wiring encapsulated in the Unit of work made each test much more understandable.
