### PR TITLE
virtualize handleAfterUndelete

### DIFF
--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -216,7 +216,7 @@ public virtual with sharing class fflib_SObjectDomain
      *
      * @throws DomainException if the current user context is not able to delete records
      **/
-    public void handleAfterUndelete() 
+    public virtual void handleAfterUndelete() 
     {
     	if(Configuration.EnforcingTriggerCRUDSecurity && !SObjectDescribe.isCreateable())
     	   throw new DomainException('Permission to create an ' + SObjectDescribe.getName() + ' denied.');


### PR DESCRIPTION
Commit https://github.com/financialforcedev/fflib-apex-common/commit/75d0e271e932414555a5abc915035ab25410ec06 and https://github.com/financialforcedev/fflib-apex-common/commit/7f6b6d8c1a589a29d45a064425f2a4f8b94945ec got merged on same date (2015.07.29) and virtualization wasn't applied to newly added onundelete.