### PR TITLE
Issue #82-Add support for creating SObjectDomain classes from generic lists

### DIFF
--- a/fflib/src/classes/fflib_Application.cls
+++ b/fflib/src/classes/fflib_Application.cls
@@ -304,6 +304,37 @@ public class fflib_Application
 			return (fflib_ISObjectDomain) domainConstructor.construct(records);
 		}	
 
+		/**
+		 * Dynamically constructs an instace of the Domain class for the given records and SObjectType
+		 *   Will return a Mock implementation if one has been provided via setMock
+		 *
+		 * @param records A list records
+		 * @param domainSObjectType SObjectType for list of records
+		 * @exception Throws an exception if the SObjectType is not specified or if constructor for Domain class was not registered for the SObjectType
+		 *
+		 * @remark Will support List<SObject> but all records in the list will be assumed to be of
+		 *         the type specified in sObjectType
+		 **/
+		public fflib_ISObjectDomain newInstance(List<SObject> records, SObjectType domainSObjectType)
+		{
+			if(domainSObjectType==null)
+				throw new DeveloperException('Must specify sObjectType');
+
+			// Mock implementation?
+			if(m_sObjectByMockDomain.containsKey(domainSObjectType))
+				return m_sObjectByMockDomain.get(domainSObjectType);
+
+			// Determine SObjectType and Apex classes for Domain class
+			Type domainConstructorClass = m_sObjectByDomainConstructorType.get(domainSObjectType);
+			if(domainConstructorClass==null)
+				throw new DeveloperException('Domain constructor class not found for SObjectType ' + domainSObjectType);
+
+			// Construct Domain class passing in the queried records
+			fflib_SObjectDomain.IConstructable2 domainConstructor = 
+				(fflib_SObjectDomain.IConstructable2) domainConstructorClass.newInstance();
+			return (fflib_ISObjectDomain) domainConstructor.construct(records, domainSObjectType);
+		}
+
 		@TestVisible
 		private void setMock(fflib_ISObjectDomain mockDomain)
 		{

--- a/fflib/src/classes/fflib_ApplicationTest.cls
+++ b/fflib/src/classes/fflib_ApplicationTest.cls
@@ -42,6 +42,18 @@ private class fflib_ApplicationTest
 		System.assert(domainObjectAcct instanceof AccountsDomain);
 		System.assertEquals(testAccountId, domainObjectAcct.getRecords()[0].Id);
 
+		// Registered Accounts domain class by SObject List
+		testAccountId = fflib_IDGenerator.generate(Account.SObjectType);
+		domainObjectAcct = 
+			Domain.newInstance(
+				new List<SObject> 
+					{ new Account( 
+						Id = testAccountId,
+						Name = 'Test Account') }
+				, Account.SObjectType);
+		System.assert(domainObjectAcct instanceof AccountsDomain);
+		System.assertEquals(testAccountId, domainObjectAcct.getRecords()[0].Id);		
+
 		// Registered Opportunities domain class by SObject List
 		Id testOpportunityId = fflib_IDGenerator.generate(Opportunity.SObjectType);
 		fflib_ISObjectDomain domainObjectOpp = 
@@ -50,6 +62,19 @@ private class fflib_ApplicationTest
 					{ new Opportunity( 
 						Id = testOpportunityId,
 						Name = 'Test Opportunity') });
+		System.assertEquals(testOpportunityId, domainObjectOpp.getRecords()[0].Id);		
+		System.assert(domainObjectOpp instanceof OpportuntiesDomain);
+
+		// Test failure for creating new instance using IConstructable2
+		// for domain class that does not support it
+		testOpportunityId = fflib_IDGenerator.generate(Opportunity.SObjectType);
+		domainObjectOpp = 
+			Domain.newInstance(
+				new List<SObject> 
+					{ new Opportunity( 
+						Id = testOpportunityId,
+						Name = 'Test Opportunity') }
+				, Opportunity.SObjectType);
 		System.assertEquals(testOpportunityId, domainObjectOpp.getRecords()[0].Id);		
 		System.assert(domainObjectOpp instanceof OpportuntiesDomain);
 
@@ -71,6 +96,18 @@ private class fflib_ApplicationTest
 
 		// Then
 		System.assert(domainObjectAcct instanceof fflib_SObjectMocks.SObjectDomain);
+
+		// When
+		domainObjectAcct = 
+			Domain.newInstance(
+				new List<SObject> 
+					{ new Account( 
+						Id = testAccountId,
+						Name = 'Test Account') }
+				, Account.SObjectType);
+
+		// Then
+		System.assert(domainObjectAcct instanceof fflib_SObjectMocks.SObjectDomain);		
 	}
 
 	@IsTest
@@ -116,6 +153,17 @@ private class fflib_ApplicationTest
 	}
 
 	@IsTest
+	private static void callingDomainFactoryWithNoSObjectTypeShouldGiveException()
+	{
+		try {
+			Domain.newInstance(new List<SObject>(), null);
+			System.assert(false, 'Expected exception');
+		} catch (fflib_Application.DeveloperException e) {
+			System.assertEquals('Must specify sObjectType', e.getMessage());
+		}
+	}	
+
+	@IsTest
 	private static void callingDomainFactoryWithInAccessableConstructorShouldGiveException()
 	{
 		try {
@@ -124,7 +172,32 @@ private class fflib_ApplicationTest
 		} catch (fflib_Application.DeveloperException e) {
 			System.assertEquals('Domain constructor class not found for SObjectType Product2', e.getMessage());
 		}
+
+		try {
+			Domain.newInstance(new List<SObject>{ new Product2(Name = 'Test Product') }, Product2.SObjectType);
+			System.assert(false, 'Expected exception');
+		} catch (fflib_Application.DeveloperException e) {
+			System.assertEquals('Domain constructor class not found for SObjectType Product2', e.getMessage());
+		}		
 	}
+
+	@IsTest
+	private static void callingDomainFactoryWithContructorClassThatDoesNotSupportIConstructableShouldGiveException()
+	{
+		try {
+			Domain.newInstance(new List<Contact>{ new Contact(LastName = 'TestContactLName') });
+			System.assert(false, 'Expected exception');
+		} catch (System.TypeException e) {
+			System.assertEquals('Invalid conversion from runtime type fflib_ApplicationTest.ContactsConstructor to fflib_SObjectDomain.IConstructable', e.getMessage());
+		}	
+
+		try {
+			Domain.newInstance(new List<SObject>{ new Contact(LastName = 'TestContactLName') }, Contact.SObjectType);
+			System.assert(false, 'Expected exception');
+		} catch (System.TypeException e) {
+			System.assertEquals('Invalid conversion from runtime type fflib_ApplicationTest.ContactsConstructor to fflib_SObjectDomain.IConstructable2', e.getMessage());
+		}		
+	}	
 
 	@IsTest
 	private static void callingUnitOfWorkFactoryShouldGivenStandardImplsAndMockImpls()
@@ -302,7 +375,8 @@ private class fflib_ApplicationTest
 			fflib_ApplicationTest.Selector,
 			new Map<SObjectType, Type> {
 					Account.SObjectType => AccountsConstructor.class,
-					Opportunity.SObjectType => OpportuntiesConstructor.class });
+					Opportunity.SObjectType => OpportuntiesConstructor.class,
+					Contact.SObjectType => ContactsConstructor.class });
 
 	public class AccountsDomain extends fflib_SObjectDomain
 	{
@@ -310,14 +384,24 @@ private class fflib_ApplicationTest
 		{
 			super(sObjectList);
 		}
+
+		public AccountsDomain(List<SObject> sObjectList, SObjectType sObjectType)
+		{
+			super(sObjectList, sObjectType);
+		}
 	}			
 
-	public class AccountsConstructor implements fflib_SObjectDomain.IConstructable
+	public class AccountsConstructor implements fflib_SObjectDomain.IConstructable2
 	{
 		public fflib_SObjectDomain construct(List<SObject> sObjectList)
 		{
 			return new AccountsDomain(sObjectList);
 		}
+
+		public fflib_SObjectDomain construct(List<SObject> sObjectList, SObjectType sObjectType)
+		{
+			return new AccountsDomain(sObjectList, sObjectType);
+		}		
 	}	
 
 	public class OpportuntiesDomain extends fflib_SObjectDomain
@@ -326,15 +410,44 @@ private class fflib_ApplicationTest
 		{
 			super(sObjectList);
 		}
+
+		public OpportuntiesDomain(List<SObject> sObjectList, SObjectType sObjectType)
+		{
+			super(sObjectList, sObjectType);
+		}		
 	}	
 
-	public class OpportuntiesConstructor implements fflib_SObjectDomain.IConstructable
+	public class OpportuntiesConstructor implements fflib_SObjectDomain.IConstructable2
 	{
 		public fflib_SObjectDomain construct(List<SObject> sObjectList)
 		{
 			return new OpportuntiesDomain(sObjectList);
 		}
-	}	
+
+		public fflib_SObjectDomain construct(List<SObject> sObjectList, SObjectType sObjectType)
+		{
+			return new OpportuntiesDomain(sObjectList, sObjectType);
+		}		
+	}
+
+	public class ContactsDomain extends fflib_SObjectDomain
+	{
+		public ContactsDomain(List<Opportunity> sObjectList)
+		{
+			super(sObjectList);
+		}
+
+		public ContactsDomain(List<SObject> sObjectList, SObjectType sObjectType)
+		{
+			super(sObjectList, sObjectType);
+		}
+	}			
+
+	// Intentionally does not support IConstructable or IConstructable2 interfaces in order to support testing
+	public class ContactsConstructor
+	{
+
+	}		
 
 	class OpportuntiesSelector extends fflib_SObjectSelector
 	{

--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -82,13 +82,30 @@ public virtual with sharing class fflib_SObjectDomain
 	
 	/**
 	 * Constructs the domain class with the data on which to apply the behaviour implemented within
+	 *
+	 * @param sObjectList A concreate list (e.g. List<Account> vs List<SObject>) of records
+
 	 **/
 	public fflib_SObjectDomain(List<SObject> sObjectList)
+	{
+		this(sObjectList, sObjectList.getSObjectType());
+	}
+
+	/**
+	 * Constructs the domain class with the data and type on which to apply the behaviour implemented within
+	 *
+	 * @param sObjectList A list (e.g. List<Opportunity>, List<Account>, etc.) of records
+	 * @param sObjectType The Schema.SObjectType of the records contained in the list
+	 *
+	 * @remark Will support List<SObject> but all records in the list will be assumed to be of
+	 *         the type specified in sObjectType
+	 **/
+	public fflib_SObjectDomain(List<SObject> sObjectList, SObjectType sObjectType)
 	{
 		// Ensure the domain class has its own copy of the data
 		Records = sObjectList.clone(); 
 		// Capture SObjectType describe for this domain class
-		SObjectDescribe = Records.getSObjectType().getDescribe();
+		SObjectDescribe = sObjectType.getDescribe();
 		// Configure the Domain object instance 
 		Configuration = new Configuration();		
 	}
@@ -255,6 +272,14 @@ public virtual with sharing class fflib_SObjectDomain
 	{
 		fflib_SObjectDomain construct(List<SObject> sObjectList);
 	}
+
+	/**
+	 * Interface used to aid the triggerHandler in constructing instances of Domain classes
+	 **/
+	public interface IConstructable2 extends IConstructable
+	{
+		fflib_SObjectDomain construct(List<SObject> sObjectList, SObjectType sObjectType);
+	}	
 	
 	/**
 	 * For Domain classes implementing the ITriggerStateful interface returns the instance 
@@ -654,6 +679,12 @@ public virtual with sharing class fflib_SObjectDomain
 			// Domain classes are initialised with lists to enforce bulkification throughout
 			super(sObjectList);
 		}
+
+		public TestSObjectDomain(List<Opportunity> sObjectList, SObjectType sObjectType)
+		{
+			// Domain classes are initialised with lists to enforce bulkification throughout
+			super(sObjectList, sObjectType);
+		}			
 		
 		public override void onApplyDefaults()
 		{

--- a/fflib/src/classes/fflib_SObjectDomainTest.cls
+++ b/fflib/src/classes/fflib_SObjectDomainTest.cls
@@ -35,6 +35,11 @@ private with sharing class fflib_SObjectDomainTest
 		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());		
 		System.assertEquals('You must provide an Account for Opportunities for existing Customers.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(Opportunity.AccountId, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field); 		
+
+		opps = new fflib_SObjectDomain.TestSObjectDomain(new SObject[] { new Opportunity ( Name = 'Test', Type = 'Existing Account' ) }, Opportunity.SObjectType );
+		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());		
+		System.assertEquals('You must provide an Account for Opportunities for existing Customers.', fflib_SObjectDomain.Errors.getAll()[0].message);
+		System.assertEquals(Opportunity.AccountId, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field);		
 	}
 	
 	@IsTest


### PR DESCRIPTION
In order to maintain full backwards compat and not impact performance of existing library, kept the code path completely separate from existing code path using IConstructable2 interface.  This resulted in some duplication of code ([fflib_Application.DomainFactory.newInstance overload](https://github.com/jondavis9898/fflib-apex-common/commit/77aabb799ca3f81792ad57641dd3011684f75840#diff-c304b0b975b1713fc151a191808e44fcR318)) but merging the newInstance methods would have resulted in a perf hit to check for IConstructable2 and also possibly using IConstructable2 when the caller really wanted to use IConstructable (without a few more unnecessary conditional checks).  While this still functionally would have worked, the small amount of duplicate code in newInstance vs. the perf hit trade-off seemed like a fair compromise.  If refactoring and/or extending IConstructable would have been an option, there are better ways of adding this enhancement.

Note that [this line](https://github.com/jondavis9898/fflib-apex-common/commit/77aabb799ca3f81792ad57641dd3011684f75840#diff-6cd4e022dccbea4cec890b12f6d560fdR383) of code from existing codebase seems a little odd since the constructor accepts a List&lt;Opportunity> instead of List&lt;Account>.  Not sure if this is a defect or intentional?
```
public AccountsDomain(List<Opportunity> sObjectList)
{
	super(sObjectList);
}
```