### PR TITLE
fix constructor param type

### DIFF
--- a/fflib/src/classes/fflib_ApplicationTest.cls
+++ b/fflib/src/classes/fflib_ApplicationTest.cls
@@ -380,7 +380,7 @@ private class fflib_ApplicationTest
 
 	public class AccountsDomain extends fflib_SObjectDomain
 	{
-		public AccountsDomain(List<Opportunity> sObjectList)
+		public AccountsDomain(List<Account> sObjectList)
 		{
 			super(sObjectList);
 		}


### PR DESCRIPTION
See #83 - Constructor parameter type should be Account not Opportunity

Seems as though APEX is not detecting a runtime error when list of Account is passed in to constructor parameter that expects list of Opportunity.  If you access any item in the list within the constructor you get the following error: "System.TypeException: Invalid conversion from runtime type Account to Opportunity".  However, when just passed through to super no error is encountered.  

Either way, per discussion in #83, should be updated to Account.