### PR TITLE
Update RecordType.sObjectType.getDescribe().getName()

### DIFF
--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -37,7 +37,7 @@ public abstract with sharing class fflib_SObjectSelector
                                                                                 , ApexClass.SObjectType.getDescribe().getName()
                                                                                 , ApexTrigger.SObjectType.getDescribe().getName()
                                                                                 , Attachment.SObjectType.getDescribe().getName()
-                                                                                , RecordType.SObjectType.getDescribe().getName() 
+                                                                                , RecordType.getSObjectType().getDescribe().getName() 
     };
      
     /**


### PR DESCRIPTION
RecordType.sObjectType.getDescribe().getName() returns "SObjectType". We need to use RecordType.getSObjectType().getDescribe().getName() to return RecordType. I've found that I need to use RecordType.getSObjectType() in place of RecordType.SObjectType everywhere in this library.