### PR TITLE
Key assertIsAccessible based on boolean value

### DIFF
--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -408,7 +408,9 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		}
 		
 		fflib_QueryFactory subselectQuery = new fflib_QueryFactory(relationship);
-		subSelectQuery.assertIsAccessible();
+		if(assertIsAccessible){
+			subSelectQuery.assertIsAccessible();
+		}
 		subselectQueryMap.put(relationship, subSelectQuery);
 		return subSelectQuery;
 	}


### PR DESCRIPTION
It appears as though the variable passed into this method is never checked before asserting that the object is available.