### PR TITLE
This commit fixes issue 86

### DIFF
--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -361,7 +361,8 @@ public virtual with sharing class fflib_SObjectDomain
 	        	pushTriggerInstance(domainClass, domainObject);	
 		}
 		
-		if(!isTriggerEventEnabled(domainClass))
+		// has this event been disabled?
+		if(!getTriggerEvent(domainClass).isEnabled(isBefore, isAfter, isInsert, isUpdate, isDelete, isUndelete))
 		{
 			return;
 		}
@@ -406,64 +407,7 @@ public virtual with sharing class fflib_SObjectDomain
 		return domain;
 	}
 	
-	/**
-	 * Utilise to check if the current trigger mode is turned off
-	 **/
-	private static boolean isTriggerEventEnabled(Type domainClass)
-	{
-		if(domainClass == null || TriggerEventByClass == null)
-		{
-			return true;
-		}
-
-		System.Debug(domainClass);
-		System.Debug(TriggerEventByClass.keySet());
-
-		if(!TriggerEventByClass.containsKey(domainClass))
-		{
-			TriggerEventByClass.put(domainClass, new TriggerEvent());
-		}
-
-		if(Trigger.isBefore)
-		{
-			if(Trigger.isInsert)
-			{
-				return TriggerEventByClass.get(domainClass).BeforeInsertEnabled;
-			}
-			else if(Trigger.isUpdate)
-			{
-				return TriggerEventByClass.get(domainClass).BeforeUpdateEnabled;
-			}
-			else if(Trigger.isDelete)
-			{
-				return TriggerEventByClass.get(domainClass).BeforeDeleteEnabled;
-			}
-		}
-		else if(Trigger.isAfter)
-		{
-			if(Trigger.isInsert)
-			{
-				return TriggerEventByClass.get(domainClass).AfterInsertEnabled;
-			}
-			else if(Trigger.isUpdate)
-			{
-				return TriggerEventByClass.get(domainClass).AfterUpdateEnabled;
-			}
-			else if(Trigger.isDelete)
-			{
-				return TriggerEventByClass.get(domainClass).AfterDeleteEnabled;
-			}
-			else if(Trigger.isUndelete)
-			{
-				return TriggerEventByClass.get(domainClass).AfterUndeleteEnabled;
-			}
-		}
-		
-		// will never get here unless there are some amazing updates to SFDC that allow tertiary logic :)
-		return true;
-	}
-
-	public TriggerEvent getTriggerEvent(Type domainClass)
+	public static TriggerEvent getTriggerEvent(Type domainClass)
 	{
 		if(!TriggerEventByClass.containsKey(domainClass))
 		{
@@ -538,6 +482,24 @@ public virtual with sharing class fflib_SObjectDomain
 		public TriggerEvent disableAllAfter()
 		{
 			return this.disableAfterInsert().disableAfterUpdate().disableAfterDelete().disableAfterUndelete();
+		}
+
+		public boolean isEnabled(Boolean isBefore, Boolean isAfter, Boolean isInsert, Boolean isUpdate, Boolean isDelete, Boolean isUndelete)
+		{
+			if(isBefore)
+			{
+				if(isInsert) return BeforeInsertEnabled;
+				else if(isUpdate) return BeforeUpdateEnabled;
+				else if(isDelete) return BeforeDeleteEnabled;
+			}
+			else if(isAfter)
+			{
+				if(isInsert) 		return AfterInsertEnabled;
+				else if(isUpdate) 	return AfterUpdateEnabled;
+				else if(isDelete) 	return AfterDeleteEnabled;
+				else if(isUndelete) return AfterUndeleteEnabled;
+			}
+			return true; // shouldnt ever get here!
 		}
 	}
 

--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -57,6 +57,11 @@ public virtual with sharing class fflib_SObjectDomain
 	public Configuration Configuration {get; private set;}    
 		
 	/**
+	 * Exposes the configuration for this domain class instance
+	 **/ 
+	public TriggerEvent TriggerEvent {get; private set;}	
+
+	/**
 	 * Useful during unit testign to assert at a more granular and robust level for errors raised during the various trigger events
 	 **/	
 	public static ErrorFactory Errors  {get; private set;}
@@ -71,6 +76,11 @@ public virtual with sharing class fflib_SObjectDomain
 	 **/
 	private static Map<Type, List<fflib_SObjectDomain>> TriggerStateByClass; 
 	
+	/**
+	 * Retains the trigger tracking configuraiton used for each domain
+	 **/
+	private static Map<Type, TriggerEvent> TriggerEventByClass;
+
 	static
 	{
 		Errors = new ErrorFactory();
@@ -78,6 +88,8 @@ public virtual with sharing class fflib_SObjectDomain
 		Test = new TestFactory();
 		
 		TriggerStateByClass = new Map<Type, List<fflib_SObjectDomain>>();
+
+		TriggerEventByClass = new Map<Type, TriggerEvent>();
 	}
 	
 	/**
@@ -349,6 +361,11 @@ public virtual with sharing class fflib_SObjectDomain
 	        	pushTriggerInstance(domainClass, domainObject);	
 		}
 		
+		if(!isTriggerEventEnabled(domainClass))
+		{
+			return;
+		}
+
 		// Invoke the applicable handler
 		if(isBefore)
 	    {
@@ -389,6 +406,141 @@ public virtual with sharing class fflib_SObjectDomain
 		return domain;
 	}
 	
+	/**
+	 * Utilise to check if the current trigger mode is turned off
+	 **/
+	private static boolean isTriggerEventEnabled(Type domainClass)
+	{
+		if(domainClass == null || TriggerEventByClass == null)
+		{
+			return true;
+		}
+
+		System.Debug(domainClass);
+		System.Debug(TriggerEventByClass.keySet());
+
+		if(!TriggerEventByClass.containsKey(domainClass))
+		{
+			TriggerEventByClass.put(domainClass, new TriggerEvent());
+		}
+
+		if(Trigger.isBefore)
+		{
+			if(Trigger.isInsert)
+			{
+				return TriggerEventByClass.get(domainClass).BeforeInsertEnabled;
+			}
+			else if(Trigger.isUpdate)
+			{
+				return TriggerEventByClass.get(domainClass).BeforeUpdateEnabled;
+			}
+			else if(Trigger.isDelete)
+			{
+				return TriggerEventByClass.get(domainClass).BeforeDeleteEnabled;
+			}
+		}
+		else if(Trigger.isAfter)
+		{
+			if(Trigger.isInsert)
+			{
+				return TriggerEventByClass.get(domainClass).AfterInsertEnabled;
+			}
+			else if(Trigger.isUpdate)
+			{
+				return TriggerEventByClass.get(domainClass).AfterUpdateEnabled;
+			}
+			else if(Trigger.isDelete)
+			{
+				return TriggerEventByClass.get(domainClass).AfterDeleteEnabled;
+			}
+			else if(Trigger.isUndelete)
+			{
+				return TriggerEventByClass.get(domainClass).AfterUndeleteEnabled;
+			}
+		}
+		
+		// will never get here unless there are some amazing updates to SFDC that allow tertiary logic :)
+		return true;
+	}
+
+	public TriggerEvent getTriggerEvent(Type domainClass)
+	{
+		if(!TriggerEventByClass.containsKey(domainClass))
+		{
+			TriggerEventByClass.put(domainClass, new TriggerEvent());
+		}
+
+		return TriggerEventByClass.get(domainClass);
+	}
+
+	public class TriggerEvent
+	{
+		public boolean BeforeInsertEnabled {get; private set;}
+		public boolean BeforeUpdateEnabled {get; private set;}
+		public boolean BeforeDeleteEnabled {get; private set;}
+
+		public boolean AfterInsertEnabled {get; private set;}
+		public boolean AfterUpdateEnabled {get; private set;}
+		public boolean AfterDeleteEnabled {get; private set;}
+		public boolean AfterUndeleteEnabled {get; private set;}
+
+		public TriggerEvent()
+		{
+			this.enableAll();
+		}
+
+		// befores
+		public TriggerEvent enableBeforeInsert() {BeforeInsertEnabled = true; return this;}
+		public TriggerEvent enableBeforeUpdate() {BeforeUpdateEnabled = true; return this;}
+		public TriggerEvent enableBeforeDelete() {BeforeDeleteEnabled = true; return this;}
+
+		public TriggerEvent disableBeforeInsert() {BeforeInsertEnabled = false; return this;}
+		public TriggerEvent disableBeforeUpdate() {BeforeUpdateEnabled = false; return this;}
+		public TriggerEvent disableBeforeDelete() {BeforeDeleteEnabled = false; return this;}
+		
+		// afters
+		public TriggerEvent enableAfterInsert() 	{AfterInsertEnabled 	= true; return this;}
+		public TriggerEvent enableAfterUpdate() 	{AfterUpdateEnabled 	= true; return this;}
+		public TriggerEvent enableAfterDelete() 	{AfterDeleteEnabled 	= true; return this;}
+		public TriggerEvent enableAfterUndelete() {AfterUndeleteEnabled 	= true; return this;}
+
+		
+		public TriggerEvent disableAfterInsert()	{AfterInsertEnabled 	= false; return this;}
+		public TriggerEvent disableAfterUpdate()	{AfterUpdateEnabled 	= false; return this;}
+		public TriggerEvent disableAfterDelete()	{AfterDeleteEnabled 	= false; return this;}
+		public TriggerEvent disableAfterUndelete(){AfterUndeleteEnabled 	= false; return this;}
+
+		public TriggerEvent enableAll()
+		{
+			return this.enableAllBefore().enableAllAfter();
+		}
+
+		public TriggerEvent disableAll()
+		{
+			return this.disableAllBefore().disableAllAfter();
+		}
+
+		public TriggerEvent enableAllBefore()
+		{
+			return this.enableBeforeInsert().enableBeforeUpdate().enableBeforeDelete();
+		}
+
+		public TriggerEvent disableAllBefore()
+		{
+			return this.disableBeforeInsert().disableBeforeUpdate().disableBeforeDelete();
+		}
+
+		public TriggerEvent enableAllAfter()
+		{
+			return this.enableAfterInsert().enableAfterUpdate().enableAfterDelete().enableAfterUndelete();
+		}
+
+		public TriggerEvent disableAllAfter()
+		{
+			return this.disableAfterInsert().disableAfterUpdate().disableAfterDelete().disableAfterUndelete();
+		}
+	}
+
 	/**
 	 * Fluent style Configuration system for Domain class creation
 	 **/

--- a/fflib/src/classes/fflib_SObjectDomain.cls
+++ b/fflib/src/classes/fflib_SObjectDomain.cls
@@ -57,11 +57,6 @@ public virtual with sharing class fflib_SObjectDomain
 	public Configuration Configuration {get; private set;}    
 		
 	/**
-	 * Exposes the configuration for this domain class instance
-	 **/ 
-	public TriggerEvent TriggerEvent {get; private set;}	
-
-	/**
 	 * Useful during unit testign to assert at a more granular and robust level for errors raised during the various trigger events
 	 **/	
 	public static ErrorFactory Errors  {get; private set;}

--- a/fflib/src/classes/fflib_SObjectDomainTest.cls
+++ b/fflib/src/classes/fflib_SObjectDomainTest.cls
@@ -228,4 +228,168 @@ private with sharing class fflib_SObjectDomainTest
 		}		
 		return testUser;
 	}
+
+	/**
+	 *	The following tests that the ability to enable/disable all trigger events works as required
+	 **/
+	@IsTest
+	private static void testDisableTriggerEventsBehaviour()
+	{
+		boolean bError = false;
+
+		String  sErrorMessage = '';
+
+		Opportunity oldOpp = (Opportunity) Opportunity.sObjectType.newSObject('006E0000006mkRQ');
+		oldOpp.Name = 'Test';
+		oldOpp.Type = 'Existing'; 
+		Opportunity newOpp = (Opportunity) Opportunity.sObjectType.newSObject('006E0000006mkRQ'); 
+		newOpp.Name = 'Test';
+		newOpp.Type = 'New'; 
+
+
+
+		// these will be called multiple times making sure the correct error message comes back out
+		// so... there are alot of tests to do here sadly and remember everything is reversed and you need to run backwards!
+		// 1 - all disabled 
+		try
+		{
+			fflib_SObjectDomain.getTriggerEvent(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class).disableAll();
+			fflib_SObjectDomain.Test.Database.onInsert(new Opportunity[] { newOpp } );
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class);
+		}
+		catch (Exception e)
+		{
+			bError = true;
+		}
+
+		System.AssertEquals(false, bError, 'Error - Trigger events have been fired when they are disabled');
+
+		////////////////////////////
+		// Insert!
+		try
+		{
+			// now lets go after insert and then before
+			fflib_SObjectDomain.getTriggerEvent(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class).enableAfterInsert();
+			fflib_SObjectDomain.Test.Database.onInsert(new Opportunity[] { newOpp } );
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class);
+		}
+		catch (Exception e)
+		{
+			sErrorMessage = e.getMessage();
+			System.Debug('Exception Fired :' + e.getMEssage());
+		}
+
+		System.AssertEquals('onAfterInsert called', sErrorMessage, 'Error - After Insert Event is enabled but did not run');
+
+		try
+		{
+			// now lets go after insert and then before
+			fflib_SObjectDomain.getTriggerEvent(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class).enableBeforeInsert();
+			fflib_SObjectDomain.Test.Database.onInsert(new Opportunity[] { newOpp } );
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class);
+		}
+		catch (Exception e)
+		{
+			sErrorMessage = e.getMessage();
+		}
+
+		System.AssertEquals('onBeforeInsert called', sErrorMessage, 'Error - Before Insert Event is enabled but did not run');
+
+		////////////////////////////
+		// Update!
+		try
+		{
+			// now lets go after insert and then before
+			fflib_SObjectDomain.getTriggerEvent(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class).enableAfterUpdate();
+			fflib_SObjectDomain.Test.Database.onUpdate(new Opportunity[] { newOpp }, new Map<Id, SObject> { newOpp.Id => oldOpp } );
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class);
+		}
+		catch (Exception e)
+		{
+			sErrorMessage = e.getMessage();
+		}
+
+		System.AssertEquals('onAfterUpdate called', sErrorMessage, 'Error - After Update Event is enabled but did not run');
+
+		try
+		{
+			// now lets go after insert and then before
+			fflib_SObjectDomain.getTriggerEvent(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class).enableBeforeUpdate();
+			fflib_SObjectDomain.Test.Database.onUpdate(new Opportunity[] { newOpp }, new Map<Id, SObject> { newOpp.Id => oldOpp } );
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class);
+		}
+		catch (Exception e)
+		{
+			sErrorMessage = e.getMessage();	
+		}
+
+		System.AssertEquals('onBeforeUpdate called', sErrorMessage, 'Error - Before Update Event is enabled but did not run');
+
+		////////////////////////////
+		// Delete!
+		try
+		{
+			// now lets go after insert and then before
+			fflib_SObjectDomain.getTriggerEvent(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class).enableAfterDelete();
+			fflib_SObjectDomain.Test.Database.onDelete(new Map<Id, Opportunity> { newOpp.Id => newOpp } );
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class);
+		}
+		catch (Exception e)
+		{
+			sErrorMessage = e.getMessage();
+		}
+
+		System.AssertEquals('onAfterDelete called', sErrorMessage, 'Error - After Delete Event is enabled but did not run');
+
+		try
+		{
+			// now lets go after insert and then before
+			fflib_SObjectDomain.getTriggerEvent(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class).enableBeforeDelete();
+			fflib_SObjectDomain.Test.Database.onDelete(new Map<Id, Opportunity> { newOpp.Id => newOpp } );
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class);
+		}
+		catch (Exception e)
+		{
+			sErrorMessage = e.getMessage();	
+		}
+
+		System.AssertEquals('onBeforeDelete called', sErrorMessage, 'Error - Before Delete Event is enabled but did not run');
+
+		////////////////////////////
+		// Undelete!
+		try
+		{
+			// now lets go after insert and then before
+			fflib_SObjectDomain.getTriggerEvent(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class).enableAfterUndelete();
+			fflib_SObjectDomain.Test.Database.onUndelete(new Opportunity[] { newOpp });
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectDisableBehaviourConstructor.class);
+		}
+		catch (Exception e)
+		{
+			sErrorMessage = e.getMessage();
+		}
+
+		System.AssertEquals('onAfterUndelete called', sErrorMessage, 'Error - After Undelete Event is enabled but did not run');
+
+		/*
+
+		fflib_SObjectDomain.Test.Database.onInsert(new Opportunity[] { opp } );
+
+
+
+		fflib_SObjectDomain.Test.Database.onUpdate(new Opportunity[] { newOpp }, new Map<Id, SObject> { newOpp.Id => oldOpp } );
+
+		fflib_SObjectDomain.Test.Database.onDelete(new Map<ID, Opportunity> { opp.Id => opp } );		
+
+		fflib_SObjectDomain.Test.Database.onUndelete(new list<Opportunity> { opp } );		
+
+
+		try {		
+			fflib_SObjectDomain.triggerHandler(fflib_SObjectDomain.TestSObjectOnValidateBehaviourConstructor.class);
+			System.assert(false, 'Expected exception');
+		} catch (Exception e) {
+			System.assertEquals('onValidate called', e.getMessage());
+		}
+		*/
+	}
 }


### PR DESCRIPTION
Simple interface to be able to disable/enable trigger events from running.

This common code is repeated many times in many instances of SFDC.  Where programatically we wish to prevent one, many or all trigger events firing for a domain.  There are many reasons why this is required and this allows the developer to easily control which events are fired by using:

````
fflib_SObjectDomain.getTriggerEvent(Accounts.class).enableAll();  // this is the default behaviour

...
// mass adjustment
.disableAll();
.disableAllBefore();
.enableAllAfter();
.disableAllAfter();

// singular
.enableBeforeInsert();
.disableBeforeInsert();

... etc

```

Currently the class is called `EventTrigger` which i'm not sold on, if anyone can think of a better name I am happy to change.

Cheers
