### PR TITLE
Fix for System.TypeException thrown on orgs that have Spring '16. Cou…

### DIFF
--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -108,7 +108,7 @@ private class fflib_QueryFactoryTest {
 
 	@isTest
 	static void invalidFieldTests(){
-		List<Exception> exceptions = new List<Exception>();
+		List<fflib_QueryFactory.InvalidFieldException> exceptions = new List<fflib_QueryFactory.InvalidFieldException>();
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		try{
 			qf.selectField('Not_a_field');


### PR DESCRIPTION
Fix for System.TypeException thrown on orgs that have Spring '16. Could be possible bug in release.

"System.TypeException: Collection store exception adding ktdev0.fflib_QueryFactory.InvalidFieldException to List<java.lang.Exception>
Stack trace: Class.ktdev0.fflib_QueryFactoryTest.invalidFieldTests: line 115, column 1"
