### PR TITLE
Fix for unit test failure when test is run in namespace packager org,…

### DIFF
--- a/fflib/src/classes/fflib_ApplicationTest.cls
+++ b/fflib/src/classes/fflib_ApplicationTest.cls
@@ -188,14 +188,16 @@ private class fflib_ApplicationTest
 			Domain.newInstance(new List<Contact>{ new Contact(LastName = 'TestContactLName') });
 			System.assert(false, 'Expected exception');
 		} catch (System.TypeException e) {
-			System.assertEquals('Invalid conversion from runtime type fflib_ApplicationTest.ContactsConstructor to fflib_SObjectDomain.IConstructable', e.getMessage());
+			System.assert(Pattern.Matches('Invalid conversion from runtime type \\w*\\.?fflib_ApplicationTest\\.ContactsConstructor to \\w*\\.?fflib_SObjectDomain\\.IConstructable',
+				e.getMessage()), 'Exception message did not match the expected pattern: ' + e.getMessage());
 		}	
 
 		try {
 			Domain.newInstance(new List<SObject>{ new Contact(LastName = 'TestContactLName') }, Contact.SObjectType);
 			System.assert(false, 'Expected exception');
 		} catch (System.TypeException e) {
-			System.assertEquals('Invalid conversion from runtime type fflib_ApplicationTest.ContactsConstructor to fflib_SObjectDomain.IConstructable2', e.getMessage());
+			System.assert(Pattern.Matches('Invalid conversion from runtime type \\w*\\.?fflib_ApplicationTest\\.ContactsConstructor to \\w*\\.?fflib_SObjectDomain\\.IConstructable2',
+				e.getMessage()), 'Exception message did not match the expected pattern: ' + e.getMessage());
 		}		
 	}	
 


### PR DESCRIPTION
… due to the presence of the namespace prefix in the expected exception messages. When I deployed the latest fflib-apex-common code into one our namespaced packager orgs, I got the following error:
```
System.AssertException: Assertion Failed: Expected: Invalid conversion from runtime type fflib_ApplicationTest.ContactsConstructor to fflib_SObjectDomain.IConstructable, Actual: Invalid conversion from runtime type PatronTicket.fflib_ApplicationTest.ContactsConstructor to PatronTicket.fflib_SObjectDomain.IConstructable

Stack trace:
Class.PatronTicket.fflib_ApplicationTest.callingDomainFactoryWithContructorClassThatDoesNotSupportIConstructableShouldGiveException: line 191, column 1
```

The code is currently looking for an exact match on the expected exception message, but because of the presence of the namespace prefix "PatronTicket" in front of the fflib classes, it doesn't match. This change uses a regular expression that is tolerant of the namespace prefix, which may, or may not be present.