### PR TITLE
Added the User SOBject to list of Standard objects without the Curren…

### DIFF
--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -33,13 +33,7 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * This overrides the Multi Currency handling, preventing it from injecting the CurrencyIsoCode fie ld for certain System objects that don't ever support it
      **/
-    private static Set<String> STANDARD_WITHOUT_CURRENCYISO = new Set<String> { AsyncApexJob.SObjectType.getDescribe().getName()
-                                                                                , ApexClass.SObjectType.getDescribe().getName()
-                                                                                , ApexTrigger.SObjectType.getDescribe().getName()
-                                                                                , Attachment.SObjectType.getDescribe().getName()
-                                                                                , RecordType.getSObjectType().getDescribe().getName()
-                                                                                , User.getSObjectType().getDescribe().getName()
-    };
+    private static Set<String> STANDARD_WITHOUT_CURRENCYISO = new Set<String> {'ApexClass', 'ApexTrigger', 'AsyncApexJob', 'Attachment', 'RecordType', 'User'};
      
     /**
      * Should this selector automatically include the FieldSet fields when building queries?

--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -33,7 +33,13 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * This overrides the Multi Currency handling, preventing it from injecting the CurrencyIsoCode fie ld for certain System objects that don't ever support it
      **/
-     private static Set<String> STANDARD_WITHOUT_CURRENCYISO = new Set<String> {'ApexClass', 'ApexTrigger', 'AsyncApexJob', 'Attachment', 'RecordType'};
+    private static Set<String> STANDARD_WITHOUT_CURRENCYISO = new Set<String> { AsyncApexJob.SObjectType.getDescribe().getName()
+                                                                                , ApexClass.SObjectType.getDescribe().getName()
+                                                                                , ApexTrigger.SObjectType.getDescribe().getName()
+                                                                                , Attachment.SObjectType.getDescribe().getName()
+                                                                                , RecordType.getSObjectType().getDescribe().getName()
+                                                                                , User.getSObjectType().getDescribe().getName()
+    };
      
     /**
      * Should this selector automatically include the FieldSet fields when building queries?


### PR DESCRIPTION
As reported in this [issue](https://github.com/financialforcedev/fflib-apex-common/issues/119), the `User` SObject is missing from the list of Standard Objects that do not have a `CurrencyISOCode` field.