### PR TITLE
Update to API 37

### DIFF
--- a/fflib/src/classes/fflib_QueryFactory.cls-meta.xml
+++ b/fflib/src/classes/fflib_QueryFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>37.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
I needed access to Asset.RecordTypeId which wasn't accessible until API 33.