### PR TITLE
Fixes https://github.com/financialforcedev/fflib-apex-common/issues/150

### DIFF
--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -503,7 +503,8 @@ private class fflib_QueryFactoryTest {
 		Schema.DescribeSObjectResult descResult = Account.SObjectType.getDescribe();
         Exception e;
 		try {
-			fflib_QueryFactory childQf = qf.subselectQuery(Contact.SObjectType);
+			SObjectType invalidType = null;
+			fflib_QueryFactory childQf = qf.subselectQuery(invalidType);
 			childQf.selectField('Id');
 		} catch (fflib_QueryFactory.InvalidSubqueryRelationshipException ex) {
 			e = ex;


### PR DESCRIPTION
The test addChildQueries_invalidChildRelationship() failed in orgs with relationship fields from Contact to Contact. This is case often seen. So I think using null instead of a specific type is less risky and tests exactly the same functionality.