### PR TITLE
new UOW feature -- manage relationship between email and record

### DIFF
--- a/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
@@ -14,42 +14,51 @@
  **/
 public interface fflib_ISObjectUnitOfWork
 {
-	/**
-	 * Register a newly created SObject instance to be inserted when commitWork is called
-	 *
-	 * @param record A newly created SObject instance to be inserted during commitWork
-	 **/
-	void registerNew(SObject record);
-	/**
-	 * Register a list of newly created SObject instances to be inserted when commitWork is called
-	 *
-	 * @param records A list of newly created SObject instances to be inserted during commitWork
-	 **/
-	void registerNew(List<SObject> records);
-	/**
-	 * Register a newly created SObject instance to be inserted when commitWork is called,
-	 *   you may also provide a reference to the parent record instance (should also be registered as new separatly)
-	 *
-	 * @param record A newly created SObject instance to be inserted during commitWork
-	 * @param relatedToParentField A SObjectField reference to the child field that associates the child record with its parent
-	 * @param relatedToParentRecord A SObject instance of the parent record (should also be registered as new separatly)
-	 **/
-	void registerNew(SObject record, Schema.sObjectField relatedToParentField, SObject relatedToParentRecord);
-	/**
-	 * Register a relationship between two records that have yet to be inserted to the database. This information will be
-	 *  used during the commitWork phase to make the references only when related records have been inserted to the database.
-	 *
-	 * @param record An existing or newly created record
-	 * @param relatedToField A SObjectField referene to the lookup field that relates the two records together
-	 * @param relatedTo A SOBject instance (yet to be commited to the database)
-	 */
-	void registerRelationship(SObject record, Schema.sObjectField relatedToField, SObject relatedTo);
-	/**
-	 * Register an existing record to be updated during the commitWork method
-	 *
-	 * @param record An existing record
-	 **/
-	void registerDirty(SObject record);
+    /**
+     * Register a newly created SObject instance to be inserted when commitWork is called
+     *
+     * @param record A newly created SObject instance to be inserted during commitWork
+     **/
+    void registerNew(SObject record);
+    /**
+     * Register a list of newly created SObject instances to be inserted when commitWork is called
+     *
+     * @param records A list of newly created SObject instances to be inserted during commitWork
+     **/
+    void registerNew(List<SObject> records);
+    /**
+     * Register a newly created SObject instance to be inserted when commitWork is called,
+     *   you may also provide a reference to the parent record instance (should also be registered as new separatly)
+     *
+     * @param record A newly created SObject instance to be inserted during commitWork
+     * @param relatedToParentField A SObjectField reference to the child field that associates the child record with its parent
+     * @param relatedToParentRecord A SObject instance of the parent record (should also be registered as new separatly)
+     **/
+    void registerNew(SObject record, Schema.sObjectField relatedToParentField, SObject relatedToParentRecord);
+    /**
+     * Register a relationship between two records that have yet to be inserted to the database. This information will be
+     *  used during the commitWork phase to make the references only when related records have been inserted to the database.
+     *
+     * @param record An existing or newly created record
+     * @param relatedToField A SObjectField referene to the lookup field that relates the two records together
+     * @param relatedTo A SOBject instance (yet to be commited to the database)
+     */
+    void registerRelationship(SObject record, Schema.sObjectField relatedToField, SObject relatedTo);
+    /**
+     * Registers a relationship between a record and a Messaging.Email where the record has yet to be inserted
+     *  to the database.  This information will be
+     *  used during the commitWork phase to make the references only when related records have been inserted to the database.
+     *
+     * @param a single email message instance
+     * @param relatedTo A SOBject instance (yet to be commited to the database)
+     */
+    void registerRelationship( Messaging.SingleEmailMessage email, SObject relatedTo );
+    /**
+     * Register an existing record to be updated during the commitWork method
+     *
+     * @param record An existing record
+     **/
+    void registerDirty(SObject record);
     /**
      * Register an existing record to be updated when commitWork is called,
      *   you may also provide a reference to the parent record instance (should also be registered as new separatly)
@@ -59,38 +68,38 @@ public interface fflib_ISObjectUnitOfWork
      * @param relatedToParentRecord A SObject instance of the parent record (should also be registered as new separatly)
      **/
     void registerDirty(SObject record, Schema.sObjectField relatedToParentField, SObject relatedToParentRecord);
-	/**
-	 * Register a list of existing records to be updated during the commitWork method
-	 *
-	 * @param records A list of existing records
-	 **/
-	void registerDirty(List<SObject> records);
-	/**
-	 * Register an existing record to be deleted during the commitWork method
-	 *
-	 * @param record An existing record
-	 **/
-	void registerDeleted(SObject record);
-	/**
-	 * Register a list of existing records to be deleted during the commitWork method
-	 *
-	 * @param records A list of existing records
-	 **/
-	void registerDeleted(List<SObject> records);
-	/**
-	 * Takes all the work that has been registered with the UnitOfWork and commits it to the database
-	 **/
-	void commitWork();
-	/**
-	 * Register a generic peace of work to be invoked during the commitWork phase
-	 *
-	 * @param work Work to be registered
-	 **/
-	void registerWork(fflib_SObjectUnitOfWork.IDoWork work);
-	/**
-	 * Registers the given email to be sent during the commitWork
-	 *
-	 * @param email Email to be sent
-	 **/	 
-	void registerEmail(Messaging.Email email);
+    /**
+     * Register a list of existing records to be updated during the commitWork method
+     *
+     * @param records A list of existing records
+     **/
+    void registerDirty(List<SObject> records);
+    /**
+     * Register an existing record to be deleted during the commitWork method
+     *
+     * @param record An existing record
+     **/
+    void registerDeleted(SObject record);
+    /**
+     * Register a list of existing records to be deleted during the commitWork method
+     *
+     * @param records A list of existing records
+     **/
+    void registerDeleted(List<SObject> records);
+    /**
+     * Takes all the work that has been registered with the UnitOfWork and commits it to the database
+     **/
+    void commitWork();
+    /**
+     * Register a generic peace of work to be invoked during the commitWork phase
+     *
+     * @param work Work to be registered
+     **/
+    void registerWork(fflib_SObjectUnitOfWork.IDoWork work);
+    /**
+     * Registers the given email to be sent during the commitWork
+     *
+     * @param email Email to be sent
+     **/
+    void registerEmail(Messaging.Email email);
 }

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -52,194 +52,209 @@
  *
  **/
 public virtual class fflib_SObjectUnitOfWork
-	implements fflib_ISObjectUnitOfWork
+    implements fflib_ISObjectUnitOfWork
 {
-	protected List<Schema.SObjectType> m_sObjectTypes = new List<Schema.SObjectType>();
+    protected List<Schema.SObjectType> m_sObjectTypes = new List<Schema.SObjectType>();
 
-	protected Map<String, List<SObject>> m_newListByType = new Map<String, List<SObject>>();
+    protected Map<String, List<SObject>> m_newListByType = new Map<String, List<SObject>>();
 
-	protected Map<String, Map<Id, SObject>> m_dirtyMapByType = new Map<String, Map<Id, SObject>>();
+    protected Map<String, Map<Id, SObject>> m_dirtyMapByType = new Map<String, Map<Id, SObject>>();
 
-	protected Map<String, Map<Id, SObject>> m_deletedMapByType = new Map<String, Map<Id, SObject>>();
+    protected Map<String, Map<Id, SObject>> m_deletedMapByType = new Map<String, Map<Id, SObject>>();
 
-	protected Map<String, Relationships> m_relationships = new Map<String, Relationships>();
+    protected Map<String, Relationships> m_relationships = new Map<String, Relationships>();
 
-	protected List<IDoWork> m_workList = new List<IDoWork>();
+    protected List<IDoWork> m_workList = new List<IDoWork>();
 
-	protected SendEmailWork m_emailWork = new SendEmailWork();
+    protected SendEmailWork m_emailWork = new SendEmailWork();
 
-	protected IDML m_dml;
+    protected IDML m_dml;
 
-	/**
-	 * Interface describes work to be performed during the commitWork method
-	 **/
-	public interface IDoWork
-	{
-		void doWork();
-	}
+    /**
+     * Interface describes work to be performed during the commitWork method
+     **/
+    public interface IDoWork
+    {
+        void doWork();
+    }
 
-	public interface IDML
-	{
-		void dmlInsert(List<SObject> objList);
-		void dmlUpdate(List<SObject> objList);
-		void dmlDelete(List<SObject> objList);
-	}
+    public interface IDML
+    {
+        void dmlInsert(List<SObject> objList);
+        void dmlUpdate(List<SObject> objList);
+        void dmlDelete(List<SObject> objList);
+    }
 
-	public class SimpleDML implements IDML
-	{
-		public void dmlInsert(List<SObject> objList){
-			insert objList;
-		}
-		public void dmlUpdate(List<SObject> objList){
-			update objList;
-		}
-		public void dmlDelete(List<SObject> objList){
-			delete objList;
-		}
-	}
-	/**
-	 * Constructs a new UnitOfWork to support work against the given object list
-	 *
-	 * @param sObjectList A list of objects given in dependency order (least dependent first)
-	 */
-	public fflib_SObjectUnitOfWork(List<Schema.SObjectType> sObjectTypes)
-	{
-		this(sObjectTypes,new SimpleDML());
-	}
+    public class SimpleDML implements IDML
+    {
+        public void dmlInsert(List<SObject> objList){
+            insert objList;
+        }
+        public void dmlUpdate(List<SObject> objList){
+            update objList;
+        }
+        public void dmlDelete(List<SObject> objList){
+            delete objList;
+        }
+    }
+    /**
+     * Constructs a new UnitOfWork to support work against the given object list
+     *
+     * @param sObjectList A list of objects given in dependency order (least dependent first)
+     */
+    public fflib_SObjectUnitOfWork(List<Schema.SObjectType> sObjectTypes)
+    {
+        this(sObjectTypes,new SimpleDML());
+    }
 
 
-	public fflib_SObjectUnitOfWork(List<Schema.SObjectType> sObjectTypes, IDML dml)
-	{
-		m_sObjectTypes = sObjectTypes.clone();
+    public fflib_SObjectUnitOfWork(List<Schema.SObjectType> sObjectTypes, IDML dml)
+    {
+        m_sObjectTypes = sObjectTypes.clone();
 
-		for(Schema.SObjectType sObjectType : m_sObjectTypes)
-		{
-			// register the type
-			handleRegisterType(sObjectType);
-		}
+        for(Schema.SObjectType sObjectType : m_sObjectTypes)
+        {
+            // register the type
+            handleRegisterType(sObjectType);
+        }
 
-		m_workList.add(m_emailWork);
+        m_relationships.put( Messaging.SingleEmailMessage.class.getName(), new Relationships());
 
-		m_dml = dml;
-	}
+        m_workList.add(m_emailWork);
 
-	// default implementations for commitWork events
-	public virtual void onRegisterType(Schema.SObjectType sObjectType) {}
-	public virtual void onCommitWorkStarting() {}
-	public virtual void onDMLStarting() {}
-	public virtual void onDMLFinished() {}
-	public virtual void onDoWorkStarting() {}
-	public virtual void onDoWorkFinished() {}
-	public virtual void onCommitWorkFinishing() {}
-	public virtual void onCommitWorkFinished(Boolean wasSuccessful) {}
+        m_dml = dml;
+    }
 
-	/**
-	 * Registers the type to be used for DML operations
-	 *
-	 * @param sObjectType - The type to register
-	 *
-	 */
-	private void handleRegisterType(Schema.SObjectType sObjectType)
-	{
-		// add type to dml operation tracking
-		m_newListByType.put(sObjectType.getDescribe().getName(), new List<SObject>());
-		m_dirtyMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
-		m_deletedMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
-		m_relationships.put(sObjectType.getDescribe().getName(), new Relationships());
+    // default implementations for commitWork events
+    public virtual void onRegisterType(Schema.SObjectType sObjectType) {}
+    public virtual void onCommitWorkStarting() {}
+    public virtual void onDMLStarting() {}
+    public virtual void onDMLFinished() {}
+    public virtual void onDoWorkStarting() {}
+    public virtual void onDoWorkFinished() {}
+    public virtual void onCommitWorkFinishing() {}
+    public virtual void onCommitWorkFinished(Boolean wasSuccessful) {}
 
-		// give derived class opportunity to register the type
-		onRegisterType(sObjectType);
-	}
+    /**
+     * Registers the type to be used for DML operations
+     *
+     * @param sObjectType - The type to register
+     *
+     */
+    private void handleRegisterType(Schema.SObjectType sObjectType)
+    {
+        // add type to dml operation tracking
+        m_newListByType.put(sObjectType.getDescribe().getName(), new List<SObject>());
+        m_dirtyMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
+        m_deletedMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
+        m_relationships.put(sObjectType.getDescribe().getName(), new Relationships());
 
-	/**
-	 * Register a generic peace of work to be invoked during the commitWork phase
-	 **/
-	public void registerWork(IDoWork work)
-	{
-		m_workList.add(work);
-	}
+        // give derived class opportunity to register the type
+        onRegisterType(sObjectType);
+    }
 
-	/**
-	 * Registers the given email to be sent during the commitWork
-	 **/
-	public void registerEmail(Messaging.Email email)
-	{
-		m_emailWork.registerEmail(email);
-	}
+    /**
+     * Register a generic peace of work to be invoked during the commitWork phase
+     **/
+    public void registerWork(IDoWork work)
+    {
+        m_workList.add(work);
+    }
 
-	/**
-	 * Register a newly created SObject instance to be inserted when commitWork is called
-	 *
-	 * @param record A newly created SObject instance to be inserted during commitWork
-	 **/
-	public void registerNew(SObject record)
-	{
-		registerNew(record, null, null);
-	}
+    /**
+     * Registers the given email to be sent during the commitWork
+     **/
+    public void registerEmail(Messaging.Email email)
+    {
+        m_emailWork.registerEmail(email);
+    }
 
-	/**
-	 * Register a list of newly created SObject instances to be inserted when commitWork is called
-	 *
-	 * @param records A list of newly created SObject instances to be inserted during commitWork
-	 **/
-	public void registerNew(List<SObject> records)
-	{
-		for(SObject record : records)
-		{
-			registerNew(record, null, null);
-		}
-	}
+    /**
+     * Register a newly created SObject instance to be inserted when commitWork is called
+     *
+     * @param record A newly created SObject instance to be inserted during commitWork
+     **/
+    public void registerNew(SObject record)
+    {
+        registerNew(record, null, null);
+    }
 
-	/**
-	 * Register a newly created SObject instance to be inserted when commitWork is called,
-	 *   you may also provide a reference to the parent record instance (should also be registered as new separatly)
-	 *
-	 * @param record A newly created SObject instance to be inserted during commitWork
-	 * @param relatedToParentField A SObjectField reference to the child field that associates the child record with its parent
-	 * @param relatedToParentRecord A SObject instance of the parent record (should also be registered as new separatly)
-	 **/
-	public void registerNew(SObject record, Schema.sObjectField relatedToParentField, SObject relatedToParentRecord)
-	{
-		if(record.Id != null)
-			throw new UnitOfWorkException('Only new records can be registered as new');
-		String sObjectType = record.getSObjectType().getDescribe().getName();
-		if(!m_newListByType.containsKey(sObjectType))
-			throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
-		m_newListByType.get(sObjectType).add(record);
-		if(relatedToParentRecord!=null && relatedToParentField!=null)
-			registerRelationship(record, relatedToParentField, relatedToParentRecord);
-	}
+    /**
+     * Register a list of newly created SObject instances to be inserted when commitWork is called
+     *
+     * @param records A list of newly created SObject instances to be inserted during commitWork
+     **/
+    public void registerNew(List<SObject> records)
+    {
+        for(SObject record : records)
+        {
+            registerNew(record, null, null);
+        }
+    }
 
-	/**
-	 * Register a relationship between two records that have yet to be inserted to the database. This information will be
-	 *  used during the commitWork phase to make the references only when related records have been inserted to the database.
-	 *
-	 * @param record An existing or newly created record
-	 * @param relatedToField A SObjectField referene to the lookup field that relates the two records together
-	 * @param relatedTo A SOBject instance (yet to be commited to the database)
-	 */
-	public void registerRelationship(SObject record, Schema.sObjectField relatedToField, SObject relatedTo)
-	{
-		String sObjectType = record.getSObjectType().getDescribe().getName();
-		if(!m_newListByType.containsKey(sObjectType))
-			throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
-		m_relationships.get(sObjectType).add(record, relatedToField, relatedTo);
-	}
+    /**
+     * Register a newly created SObject instance to be inserted when commitWork is called,
+     *   you may also provide a reference to the parent record instance (should also be registered as new separatly)
+     *
+     * @param record A newly created SObject instance to be inserted during commitWork
+     * @param relatedToParentField A SObjectField reference to the child field that associates the child record with its parent
+     * @param relatedToParentRecord A SObject instance of the parent record (should also be registered as new separatly)
+     **/
+    public void registerNew(SObject record, Schema.sObjectField relatedToParentField, SObject relatedToParentRecord)
+    {
+        if(record.Id != null)
+            throw new UnitOfWorkException('Only new records can be registered as new');
+        String sObjectType = record.getSObjectType().getDescribe().getName();
+        if(!m_newListByType.containsKey(sObjectType))
+            throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
+        m_newListByType.get(sObjectType).add(record);
+        if(relatedToParentRecord!=null && relatedToParentField!=null)
+            registerRelationship(record, relatedToParentField, relatedToParentRecord);
+    }
 
-	/**
-	 * Register an existing record to be updated during the commitWork method
-	 *
-	 * @param record An existing record
-	 **/
-	public void registerDirty(SObject record)
-	{
-		if(record.Id == null)
-			throw new UnitOfWorkException('New records cannot be registered as dirty');
-		String sObjectType = record.getSObjectType().getDescribe().getName();
-		if(!m_dirtyMapByType.containsKey(sObjectType))
-			throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
-		m_dirtyMapByType.get(sObjectType).put(record.Id, record);
-	}
+    /**
+     * Register a relationship between two records that have yet to be inserted to the database. This information will be
+     *  used during the commitWork phase to make the references only when related records have been inserted to the database.
+     *
+     * @param record An existing or newly created record
+     * @param relatedToField A SObjectField referene to the lookup field that relates the two records together
+     * @param relatedTo A SOBject instance (yet to be commited to the database)
+     */
+    public void registerRelationship(SObject record, Schema.sObjectField relatedToField, SObject relatedTo)
+    {
+        String sObjectType = record.getSObjectType().getDescribe().getName();
+        if(!m_newListByType.containsKey(sObjectType))
+            throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
+        m_relationships.get(sObjectType).add(record, relatedToField, relatedTo);
+    }
+
+    /**
+     * Registers a relationship between a record and a Messaging.Email where the record has yet to be inserted
+     *  to the database.  This information will be
+     *  used during the commitWork phase to make the references only when related records have been inserted to the database.
+     *
+     * @param a single email message instance
+     * @param relatedTo A SOBject instance (yet to be commited to the database)
+     */
+    public void registerRelationship( Messaging.SingleEmailMessage email, SObject relatedTo )
+    {
+        m_relationships.get( Messaging.SingleEmailMessage.class.getName() ).add(email, relatedTo);
+    }
+
+    /**
+     * Register an existing record to be updated during the commitWork method
+     *
+     * @param record An existing record
+     **/
+    public void registerDirty(SObject record)
+    {
+        if(record.Id == null)
+            throw new UnitOfWorkException('New records cannot be registered as dirty');
+        String sObjectType = record.getSObjectType().getDescribe().getName();
+        if(!m_dirtyMapByType.containsKey(sObjectType))
+            throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
+        m_dirtyMapByType.get(sObjectType).put(record.Id, record);
+    }
 
     /**
      * Register an existing record to be updated when commitWork is called,
@@ -261,160 +276,197 @@ public virtual class fflib_SObjectUnitOfWork
             registerRelationship(record, relatedToParentField, relatedToParentRecord);
     }
 
-	/**
-	 * Register a list of existing records to be updated during the commitWork method
-	 *
-	 * @param records A list of existing records
-	 **/
-	public void registerDirty(List<SObject> records)
-	{
-		for(SObject record : records)
-		{
-			this.registerDirty(record);
-		}
-	}
+    /**
+     * Register a list of existing records to be updated during the commitWork method
+     *
+     * @param records A list of existing records
+     **/
+    public void registerDirty(List<SObject> records)
+    {
+        for(SObject record : records)
+        {
+            this.registerDirty(record);
+        }
+    }
 
-	/**
-	 * Register an existing record to be deleted during the commitWork method
-	 *
-	 * @param record An existing record
-	 **/
-	public void registerDeleted(SObject record)
-	{
-		if(record.Id == null)
-			throw new UnitOfWorkException('New records cannot be registered for deletion');
-		String sObjectType = record.getSObjectType().getDescribe().getName();
-		if(!m_deletedMapByType.containsKey(sObjectType))
-			throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
-		m_deletedMapByType.get(sObjectType).put(record.Id, record);
-	}
+    /**
+     * Register an existing record to be deleted during the commitWork method
+     *
+     * @param record An existing record
+     **/
+    public void registerDeleted(SObject record)
+    {
+        if(record.Id == null)
+            throw new UnitOfWorkException('New records cannot be registered for deletion');
+        String sObjectType = record.getSObjectType().getDescribe().getName();
+        if(!m_deletedMapByType.containsKey(sObjectType))
+            throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
+        m_deletedMapByType.get(sObjectType).put(record.Id, record);
+    }
 
-	/**
-	 * Register a list of existing records to be deleted during the commitWork method
-	 *
-	 * @param records A list of existing records
-	 **/
-	public void registerDeleted(List<SObject> records)
-	{
-		for(SObject record : records)
-		{
-			this.registerDeleted(record);
-		}
-	}
+    /**
+     * Register a list of existing records to be deleted during the commitWork method
+     *
+     * @param records A list of existing records
+     **/
+    public void registerDeleted(List<SObject> records)
+    {
+        for(SObject record : records)
+        {
+            this.registerDeleted(record);
+        }
+    }
 
-	/**
-	 * Takes all the work that has been registered with the UnitOfWork and commits it to the database
-	 **/
-	public void commitWork()
-	{
-		// notify we're starting the commit work
-		onCommitWorkStarting();
+    /**
+     * Takes all the work that has been registered with the UnitOfWork and commits it to the database
+     **/
+    public void commitWork()
+    {
+        // notify we're starting the commit work
+        onCommitWorkStarting();
 
-		// Wrap the work in its own transaction
-		Savepoint sp = Database.setSavePoint();
-		Boolean wasSuccessful = false;
-		try
-		{
-			// notify we're starting the DML operations
-			onDMLStarting();
-			// Insert by type
-			for(Schema.SObjectType sObjectType : m_sObjectTypes)
-			{
-				m_relationships.get(sObjectType.getDescribe().getName()).resolve();
-				m_dml.dmlInsert(m_newListByType.get(sObjectType.getDescribe().getName()));
-			}
-			// Update by type
-			for(Schema.SObjectType sObjectType : m_sObjectTypes)
-				m_dml.dmlUpdate(m_dirtyMapByType.get(sObjectType.getDescribe().getName()).values());
-			// Delete by type (in reverse dependency order)
-			Integer objectIdx = m_sObjectTypes.size() - 1;
-			while(objectIdx>=0)
-				m_dml.dmlDelete(m_deletedMapByType.get(m_sObjectTypes[objectIdx--].getDescribe().getName()).values());
-			// notify we're done with DML
-			onDMLFinished();
+        // Wrap the work in its own transaction
+        Savepoint sp = Database.setSavePoint();
+        Boolean wasSuccessful = false;
+        try
+        {
+            // notify we're starting the DML operations
+            onDMLStarting();
+            // Insert by type
+            for(Schema.SObjectType sObjectType : m_sObjectTypes)
+            {
+                m_relationships.get(sObjectType.getDescribe().getName()).resolve();
+                m_dml.dmlInsert(m_newListByType.get(sObjectType.getDescribe().getName()));
+            }
+            // Update by type
+            for(Schema.SObjectType sObjectType : m_sObjectTypes)
+                m_dml.dmlUpdate(m_dirtyMapByType.get(sObjectType.getDescribe().getName()).values());
+            // Delete by type (in reverse dependency order)
+            Integer objectIdx = m_sObjectTypes.size() - 1;
+            while(objectIdx>=0)
+                m_dml.dmlDelete(m_deletedMapByType.get(m_sObjectTypes[objectIdx--].getDescribe().getName()).values());
 
-			// notify we're starting to process registered work
-			onDoWorkStarting();
-			// Generic work
-			for(IDoWork work : m_workList)
-				work.doWork();
-			// notify we've completed processing registered work
-			onDoWorkFinished();
+            // manage any record relationships to emails that need to be resolved.
+            m_relationships.get( Messaging.SingleEmailMessage.class.getName() ).resolve();
 
-			// notify we've completed all steps and are in the final stage of completing
-			onCommitWorkFinishing();
+            // notify we're done with DML
+            onDMLFinished();
 
-			// mark tracker to indicate success
-			wasSuccessful = true;
-		}
-		catch (Exception e)
-		{
-			// Rollback
-			Database.rollback(sp);
-			// Throw exception on to caller
-			throw e;
-		}
-		finally
-		{
-			// notify we're done with commit work
-			onCommitWorkFinished(wasSuccessful);
-		}
-	}
+            // notify we're starting to process registered work
+            onDoWorkStarting();
+            // Generic work
+            for(IDoWork work : m_workList)
+                work.doWork();
+            // notify we've completed processing registered work
+            onDoWorkFinished();
 
-	private class Relationships
-	{
-		private List<Relationship> m_relationships = new List<Relationship>();
+            // notify we've completed all steps and are in the final stage of completing
+            onCommitWorkFinishing();
 
-		public void resolve()
-		{
-			// Resolve relationships
-			for(Relationship relationship : m_relationships)
-				relationship.Record.put(relationship.RelatedToField, relationship.RelatedTo.Id);
-		}
+            // mark tracker to indicate success
+            wasSuccessful = true;
+        }
+        catch (Exception e)
+        {
+            // Rollback
+            Database.rollback(sp);
+            // Throw exception on to caller
+            throw e;
+        }
+        finally
+        {
+            // notify we're done with commit work
+            onCommitWorkFinished(wasSuccessful);
+        }
+    }
 
-		public void add(SObject record, Schema.sObjectField relatedToField, SObject relatedTo)
-		{
-			// Relationship to resolve
-			Relationship relationship = new Relationship();
-			relationship.Record = record;
-			relationship.RelatedToField = relatedToField;
-			relationship.RelatedTo = relatedTo;
-			m_relationships.add(relationship);
-		}
-	}
+    private class Relationships
+    {
+        private List<IRelationship> m_relationships = new List<IRelationship>();
 
-	private class Relationship
-	{
-		public SObject Record;
-		public Schema.sObjectField RelatedToField;
-		public SObject RelatedTo;
-	}
+        public void resolve()
+        {
+            // Resolve relationships
+            for(IRelationship relationship : m_relationships)
+            {
+                //relationship.Record.put(relationship.RelatedToField, relationship.RelatedTo.Id);
+                relationship.resolve();
+            }
 
-	/**
-	 * UnitOfWork Exception
-	 **/
-	public class UnitOfWorkException extends Exception {}
+        }
 
-	/**
-	 * Internal implementation of Messaging.sendEmail, see outer class registerEmail method
-	 **/
-	private class SendEmailWork implements IDoWork
-	{
-		private List<Messaging.Email> emails;
+        public void add(SObject record, Schema.sObjectField relatedToField, SObject relatedTo)
+        {
+            // Relationship to resolve
+            Relationship relationship = new Relationship();
+            relationship.Record = record;
+            relationship.RelatedToField = relatedToField;
+            relationship.RelatedTo = relatedTo;
+            m_relationships.add(relationship);
+        }
 
-		public SendEmailWork()
-		{
-			this.emails = new List<Messaging.Email>();
-		}
+        public void add(Messaging.SingleEmailMessage email, SObject relatedTo)
+        {
+            EmailRelationship emailRelationship = new EmailRelationship();
+            emailRelationship.email = email;
+            emailRelationship.relatedTo = relatedTo;
+            m_relationships.add(emailRelationship);
+        }
+    }
 
-		public void registerEmail(Messaging.Email email)
-		{
-			this.emails.add(email);
-		}
+    private interface IRelationship
+    {
+        void resolve();
+    }
 
-		public void doWork()
-		{
-			if(emails.size() > 0) Messaging.sendEmail(emails);
-		}
-	}
+    private class Relationship implements IRelationship
+    {
+        public SObject Record;
+        public Schema.sObjectField RelatedToField;
+        public SObject RelatedTo;
+
+        public void resolve()
+        {
+            this.Record.put( this.RelatedToField, this.RelatedTo.Id);
+        }
+    }
+
+    private class EmailRelationship implements IRelationship
+    {
+        public Messaging.SingleEmailMessage email;
+        public SObject relatedTo;
+
+        public void resolve()
+        {
+            this.email.setWhatId( this.RelatedTo.Id );
+        }
+    }
+
+    /**
+     * UnitOfWork Exception
+     **/
+    public class UnitOfWorkException extends Exception {}
+
+    /**
+     * Internal implementation of Messaging.sendEmail, see outer class registerEmail method
+     **/
+    private class SendEmailWork implements IDoWork
+    {
+        private List<Messaging.Email> emails;
+
+        public SendEmailWork()
+        {
+            this.emails = new List<Messaging.Email>();
+        }
+
+        public void registerEmail(Messaging.Email email)
+        {
+            this.emails.add(email);
+        }
+
+        public void doWork()
+        {
+            if(emails.size() > 0) Messaging.sendEmail(emails);
+        }
+    }
 }

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -2,22 +2,22 @@
  * Copyright (c), FinancialForce.com, inc
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  *   are permitted provided that the following conditions are met:
  *
- * - Redistributions of source code must retain the above copyright notice, 
+ * - Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice, 
- *      this list of conditions and the following disclaimer in the documentation 
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
  *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors 
- *      may be used to endorse or promote products derived from this software without 
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
  *      specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
- *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
- *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
- *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
  *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
@@ -25,406 +25,438 @@
 **/
 
 @IsTest
-private with sharing class fflib_SObjectUnitOfWorkTest 
+private with sharing class fflib_SObjectUnitOfWorkTest
 {
-	// SObjects (in order of dependency) used by UnitOfWork in tests bellow	
-	private static List<Schema.SObjectType> MY_SOBJECTS = 
-		new Schema.SObjectType[] { 
-			Product2.SObjectType, 
-			PricebookEntry.SObjectType, 
-			Opportunity.SObjectType, 
-			OpportunityLineItem.SObjectType };
+    // SObjects (in order of dependency) used by UnitOfWork in tests bellow
+    private static List<Schema.SObjectType> MY_SOBJECTS =
+        new Schema.SObjectType[] {
+            Product2.SObjectType,
+            PricebookEntry.SObjectType,
+            Opportunity.SObjectType,
+            OpportunityLineItem.SObjectType };
 
-	@isTest
-	private static void testUnitOfWorkNewDirtyDelete()
-	{
-		// Insert Opporunities with UnitOfWork
-		{
-			fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
-			for(Integer o=0; o<10; o++)
-			{
-				Opportunity opp = new Opportunity();
-				opp.Name = 'UoW Test Name ' + o;
-				opp.StageName = 'Open';
-				opp.CloseDate = System.today();
-				uow.registerNew(new List<SObject>{opp});
-				for(Integer i=0; i<o+1; i++)
-				{
-					Product2 product = new Product2();
-					product.Name = opp.Name + ' : Product : ' + i;
-					uow.registerNew(new List<SObject>{product});
-					PricebookEntry pbe = new PricebookEntry();
-					pbe.UnitPrice = 10;
-					pbe.IsActive = true;
-					pbe.UseStandardPrice = false;
-					pbe.Pricebook2Id = Test.getStandardPricebookId();
-					uow.registerNew(pbe, PricebookEntry.Product2Id, product);
-					OpportunityLineItem oppLineItem = new OpportunityLineItem();
-					oppLineItem.Quantity = 1;
-					oppLineItem.TotalPrice = 10;
-					uow.registerRelationship(oppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
-					uow.registerNew(oppLineItem, OpportunityLineItem.OpportunityId, opp);
-				}
-			}
-			uow.commitWork();
-		}
-		
-		// Assert Results 
-		assertResults('UoW');
-		// TODO: Need to re-instate this check with a better approach, as it is not possible when 
-		//       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
-		// System.assertEquals(5 /* Oddly a setSavePoint consumes a DML */, Limits.getDmlStatements());
+    @isTest
+    private static void testUnitOfWorkEmail()
+    {
+        string testRecordName = 'UoW Test Name 1';
 
-		// Records to update
-		List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name like 'UoW Test Name %' order by Name];
-		
-		// Update some records with UnitOfWork
-		{
-			fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);	
-			Opportunity opp = opps[0];
-			opp.Name = opp.Name + ' Changed';
-			uow.registerDirty(new List<SObject>{opp});
-			Product2 product = new Product2();
-			product.Name = opp.Name + ' : New Product';
-			uow.registerNew(new List<SObject>{product});
-			PricebookEntry pbe = new PricebookEntry();
-			pbe.UnitPrice = 10;
-			pbe.IsActive = true;
-			pbe.UseStandardPrice = false;
-			pbe.Pricebook2Id = Test.getStandardPricebookId();
-			uow.registerNew(pbe, PricebookEntry.Product2Id, product);
-			OpportunityLineItem newOppLineItem = new OpportunityLineItem();
-			newOppLineItem.Quantity = 1;
-			newOppLineItem.TotalPrice = 10;
-			uow.registerRelationship(newOppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
-			uow.registerNew(newOppLineItem, OpportunityLineItem.OpportunityId, opp);
-			OpportunityLineItem existingOppLine = opp.OpportunityLineItems[0];
-			// Test that operations on the same object can be daisy chained, and the same object registered as dirty more than once
-			// This verifies that using a Map to back the dirty records collection prevents duplicate registration.
-			existingOppLine.Quantity = 2;
-			uow.registerDirty(new List<SObject>{existingOppLine});
-			existingOppLine.TotalPrice = 20;
-			uow.registerDirty(new List<SObject>{existingOppLine});
-			uow.commitWork();
-		}
-		
-		// Assert Results
-		// TODO: Need to re-instate this check with a better approach, as it is not possible when 
-		//       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
-		// System.assertEquals(11, Limits.getDmlStatements());
-		opps = [select Id, Name, (Select Id, PricebookEntry.Product2.Name, Quantity, TotalPrice from OpportunityLineItems Order By PricebookEntry.Product2.Name) from Opportunity where Name like 'UoW Test Name %' order by Name];
-		System.assertEquals(10, opps.size());
-		System.assertEquals('UoW Test Name 0 Changed', opps[0].Name);
-		System.assertEquals(2, opps[0].OpportunityLineItems.size());
-		// Verify that both fields were updated properly
-		System.assertEquals(2, opps[0].OpportunityLineItems[0].Quantity);
-		System.assertEquals(20, opps[0].OpportunityLineItems[0].TotalPrice);
-		System.assertEquals('UoW Test Name 0 Changed : New Product', opps[0].OpportunityLineItems[1].PricebookEntry.Product2.Name);
-		
-		// Delete some records with the UnitOfWork
-		{
-			fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);	
-			uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1].PricebookEntry.Product2}); // Delete PricebookEntry Product 
-			uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1].PricebookEntry}); // Delete PricebookEntry
-			uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1]}); // Delete OpportunityLine Item
-			// Register the same deletions more than once.
-			// This verifies that using a Map to back the deleted records collection prevents duplicate registration.
-			uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1].PricebookEntry.Product2}); // Delete PricebookEntry Product 
-			uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1].PricebookEntry}); // Delete PricebookEntry
-			uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1]}); // Delete OpportunityLine Item
-			uow.commitWork();
-		}
-		
-		// Assert Results
-		// TODO: Need to re-instate this check with a better approach, as it is not possible when 
-		//       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
-		// System.assertEquals(15, Limits.getDmlStatements());
-		opps = [select Id, Name, (Select Id, PricebookEntry.Product2.Name, Quantity from OpportunityLineItems Order By PricebookEntry.Product2.Name) from Opportunity where Name like 'UoW Test Name %' order by Name];
-		List<Product2> prods = [Select Id from Product2 where Name = 'UoW Test Name 0 Changed : New Product'];
-		System.assertEquals(10, opps.size());
-		System.assertEquals('UoW Test Name 0 Changed', opps[0].Name);
-		System.assertEquals(1, opps[0].OpportunityLineItems.size()); // Should have deleted OpportunityLineItem added above
-		System.assertEquals(0, prods.size()); // Should have deleted Product added above
-	}
-	
-	private static void assertResults(String prefix)
-	{
-		// Standard Assertions on tests data inserted by tests
-		String filter = prefix + ' Test Name %';
-		List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name like :filter order by Name];
-		System.assertEquals(10, opps.size());
-		System.assertEquals(1, opps[0].OpportunityLineItems.size());
-		System.assertEquals(2, opps[1].OpportunityLineItems.size());
-		System.assertEquals(3, opps[2].OpportunityLineItems.size());
-		System.assertEquals(4, opps[3].OpportunityLineItems.size());
-		System.assertEquals(5, opps[4].OpportunityLineItems.size());
-		System.assertEquals(6, opps[5].OpportunityLineItems.size());
-		System.assertEquals(7, opps[6].OpportunityLineItems.size());
-		System.assertEquals(8, opps[7].OpportunityLineItems.size());
-		System.assertEquals(9, opps[8].OpportunityLineItems.size());
-		System.assertEquals(10, opps[9].OpportunityLineItems.size());
-	}
+        Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
+        email.setToAddresses(new list<String>{ 'foobar@test.com' });
+        email.setPlainTextBody('See Spot run.');
 
-	/**
-	 * Create uow with new records and commit
-	 *
-	 *	Testing: 
-	 *
-	 *		- Correct events are fired when commitWork completes successfully
-	 *
-	 */
-	@isTest
-	private static void testDerivedUnitOfWork_CommitSuccess() 
-	{
-		// Insert Opporunities with UnitOfWork
-		DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
-		for(Integer o=0; o<10; o++)
-		{
-			Opportunity opp = new Opportunity();
-			opp.Name = 'UoW Test Name ' + o;
-			opp.StageName = 'Open';
-			opp.CloseDate = System.today();
-			uow.registerNew(new List<SObject>{opp});
-			for(Integer i=0; i<o+1; i++)
-			{
-				Product2 product = new Product2();
-				product.Name = opp.Name + ' : Product : ' + i;
-				uow.registerNew(new List<SObject>{product});
-				PricebookEntry pbe = new PricebookEntry();
-				pbe.UnitPrice = 10;
-				pbe.IsActive = true;
-				pbe.UseStandardPrice = false;
-				pbe.Pricebook2Id = Test.getStandardPricebookId();
-				uow.registerNew(pbe, PricebookEntry.Product2Id, product);
-				OpportunityLineItem oppLineItem = new OpportunityLineItem();
-				oppLineItem.Quantity = 1;
-				oppLineItem.TotalPrice = 10;
-				uow.registerRelationship(oppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
-				uow.registerNew(oppLineItem, OpportunityLineItem.OpportunityId, opp);
-			}
-		}
-		uow.commitWork();
-		
-		// Assert Results 
-		assertResults('UoW');
+        fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
 
-		assertEvents(new List<String> {
-				'onCommitWorkStarting'
-				, 'onDMLStarting'
-				, 'onDMLFinished'
-				, 'onDoWorkStarting'
-				, 'onDoWorkFinished'
-				, 'onCommitWorkFinishing'
-				, 'onCommitWorkFinished - true'
-			}
-			, uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
-	}
+        Opportunity opp = new Opportunity();
+        opp.Name = testRecordName;
+        opp.StageName = 'Open';
+        opp.CloseDate = System.today();
+        uow.registerNew( opp );
 
-	/**
-	 * Create uow with data that results in DML Exception
-	 *
-	 *	Testing: 
-	 *
-	 *		- Correct events are fired when commitWork fails during DML processing
-	 *
-	 */
-	@isTest
-	private static void testDerivedUnitOfWork_CommitDMLFail() 
-	{
-		// Insert Opporunities with UnitOfWork forcing a failure on DML by not setting 'Name' field
-		DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
-		Opportunity opp = new Opportunity();
-		uow.registerNew(new List<SObject>{opp});
-		Boolean didFail = false;
-		System.DmlException caughtEx = null;
+        uow.registerEmail( email );
 
-		try {
-			uow.commitWork();    
-		}
-		catch (System.DmlException dmlex) {
-			didFail = true;
-			caughtEx = dmlex;
-		}	
-		
-		// Assert Results 
-		System.assertEquals(didFail, true, 'didFail');
-		System.assert(caughtEx.getMessage().contains('REQUIRED_FIELD_MISSING'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
+        uow.registerRelationship( email, opp );
 
-		assertEvents(new List<String> { 
-				'onCommitWorkStarting'
-				, 'onDMLStarting'
-				, 'onCommitWorkFinished - false' 
-			}
-			, uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
-	}
+        uow.commitWork();
 
-	/**
-	 * Create uow with work that fails
-	 *
-	 *	Testing: 
-	 *
-	 *		- Correct events are fired when commitWork fails during DoWork processing
-	 *
-	 */
-	@isTest
-	private static void testDerivedUnitOfWork_CommitDoWorkFail() 
-	{
-		// Insert Opporunities with UnitOfWork
-		DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
-		Opportunity opp = new Opportunity();
-		opp.Name = 'UoW Test Name 1';
-		opp.StageName = 'Open';
-		opp.CloseDate = System.today();
-		uow.registerNew(new List<SObject>{opp});
+        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name = :testRecordName order by Name];
 
-		// register work that will fail during processing
-		FailDoingWork fdw = new FailDoingWork();
-		uow.registerWork(fdw);
+        // assert that an email was sent
+        system.assertEquals(1, Limits.getEmailInvocations());
 
-		Boolean didFail = false;
-		FailDoingWorkException caughtEx = null;
+        System.assertEquals(1, opps.size());
+    }
 
-		try {
-			uow.commitWork();    
-		}
-		catch (FailDoingWorkException fdwe) {
-			didFail = true;
-			caughtEx = fdwe;
-		}	
-		
-		// Assert Results 
-		System.assertEquals(didFail, true, 'didFail');
-		System.assert(caughtEx.getMessage().contains('Work failed.'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
+    @isTest
+    private static void testUnitOfWorkNewDirtyDelete()
+    {
+        // Insert Opporunities with UnitOfWork
+        {
+            fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
+            for(Integer o=0; o<10; o++)
+            {
+                Opportunity opp = new Opportunity();
+                opp.Name = 'UoW Test Name ' + o;
+                opp.StageName = 'Open';
+                opp.CloseDate = System.today();
+                uow.registerNew(new List<SObject>{opp});
+                for(Integer i=0; i<o+1; i++)
+                {
+                    Product2 product = new Product2();
+                    product.Name = opp.Name + ' : Product : ' + i;
+                    uow.registerNew(new List<SObject>{product});
+                    PricebookEntry pbe = new PricebookEntry();
+                    pbe.UnitPrice = 10;
+                    pbe.IsActive = true;
+                    pbe.UseStandardPrice = false;
+                    pbe.Pricebook2Id = Test.getStandardPricebookId();
+                    uow.registerNew(pbe, PricebookEntry.Product2Id, product);
+                    OpportunityLineItem oppLineItem = new OpportunityLineItem();
+                    oppLineItem.Quantity = 1;
+                    oppLineItem.TotalPrice = 10;
+                    uow.registerRelationship(oppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
+                    uow.registerNew(oppLineItem, OpportunityLineItem.OpportunityId, opp);
+                }
+            }
 
-		assertEvents(new List<String> { 
-				'onCommitWorkStarting'
-				, 'onDMLStarting'
-				, 'onDMLFinished'
-				, 'onDoWorkStarting'
-				, 'onCommitWorkFinished - false' 
-			}
-			, uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
-	}	
+            uow.commitWork();
+        }
 
-	/**
-	 * Assert that actual events exactly match expected events (size, order and name)
-	 * and types match expected types
-	 */
-	private static void assertEvents(List<String> expectedEvents, List<String> actualEvents, Set<Schema.SObjectType> expectedTypes, Set<Schema.SObjectType> actualTypes) 
-	{
-		// assert that events match
-		System.assertEquals(expectedEvents.size(), actualEvents.size(), 'events size');
-		for (Integer i = 0; i < expectedEvents.size(); i++)
-		{
-			System.assertEquals(expectedEvents[i], actualEvents[i], String.format('Event {0} was not fired in order expected.', new List<String> { expectedEvents[i] }));
-		}
+        // Assert Results
+        assertResults('UoW');
+        // TODO: Need to re-instate this check with a better approach, as it is not possible when
+        //       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
+        // System.assertEquals(5 /* Oddly a setSavePoint consumes a DML */, Limits.getDmlStatements());
 
-		// assert that types match
-		System.assertEquals(expectedTypes.size(), actualTypes.size(), 'types size');
-		for (Schema.SObjectType sObjectType :expectedTypes)
-		{
-			System.assertEquals(true, actualTypes.contains(sObjectType), String.format('Type {0} was not registered.', new List<String> { sObjectType.getDescribe().getName() }));	
-		}
-	}
+        // Records to update
+        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name like 'UoW Test Name %' order by Name];
 
-	/**
-	 * DoWork implementation that throws exception during processing
-	 */
-	private class FailDoingWork implements fflib_SObjectUnitOfWork.IDoWork
-	{
-		public void doWork()
-		{
-			throw new FailDoingWorkException('Work failed.');
-		}
-	}
+        // Update some records with UnitOfWork
+        {
+            fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
+            Opportunity opp = opps[0];
+            opp.Name = opp.Name + ' Changed';
+            uow.registerDirty(new List<SObject>{opp});
+            Product2 product = new Product2();
+            product.Name = opp.Name + ' : New Product';
+            uow.registerNew(new List<SObject>{product});
+            PricebookEntry pbe = new PricebookEntry();
+            pbe.UnitPrice = 10;
+            pbe.IsActive = true;
+            pbe.UseStandardPrice = false;
+            pbe.Pricebook2Id = Test.getStandardPricebookId();
+            uow.registerNew(pbe, PricebookEntry.Product2Id, product);
+            OpportunityLineItem newOppLineItem = new OpportunityLineItem();
+            newOppLineItem.Quantity = 1;
+            newOppLineItem.TotalPrice = 10;
+            uow.registerRelationship(newOppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
+            uow.registerNew(newOppLineItem, OpportunityLineItem.OpportunityId, opp);
+            OpportunityLineItem existingOppLine = opp.OpportunityLineItems[0];
+            // Test that operations on the same object can be daisy chained, and the same object registered as dirty more than once
+            // This verifies that using a Map to back the dirty records collection prevents duplicate registration.
+            existingOppLine.Quantity = 2;
+            uow.registerDirty(new List<SObject>{existingOppLine});
+            existingOppLine.TotalPrice = 20;
+            uow.registerDirty(new List<SObject>{existingOppLine});
+            uow.commitWork();
+        }
 
-	/**
-	 * Derived unit of work that tracks event notifications and handle registration of type
-	 */
-	private class DerivedUnitOfWork extends fflib_SObjectUnitOfWork
-	{
-		private List<String> m_commitWorkEventsFired = new List<String>();
-		private Set<Schema.SObjectType> m_registeredTypes = new Set<Schema.SObjectType>();
+        // Assert Results
+        // TODO: Need to re-instate this check with a better approach, as it is not possible when
+        //       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
+        // System.assertEquals(11, Limits.getDmlStatements());
+        opps = [select Id, Name, (Select Id, PricebookEntry.Product2.Name, Quantity, TotalPrice from OpportunityLineItems Order By PricebookEntry.Product2.Name) from Opportunity where Name like 'UoW Test Name %' order by Name];
+        System.assertEquals(10, opps.size());
+        System.assertEquals('UoW Test Name 0 Changed', opps[0].Name);
+        System.assertEquals(2, opps[0].OpportunityLineItems.size());
+        // Verify that both fields were updated properly
+        System.assertEquals(2, opps[0].OpportunityLineItems[0].Quantity);
+        System.assertEquals(20, opps[0].OpportunityLineItems[0].TotalPrice);
+        System.assertEquals('UoW Test Name 0 Changed : New Product', opps[0].OpportunityLineItems[1].PricebookEntry.Product2.Name);
 
-		public List<String> getCommitWorkEventsFired()
-		{
-			return m_commitWorkEventsFired.clone();
-		}
+        // Delete some records with the UnitOfWork
+        {
+            fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
+            uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1].PricebookEntry.Product2}); // Delete PricebookEntry Product
+            uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1].PricebookEntry}); // Delete PricebookEntry
+            uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1]}); // Delete OpportunityLine Item
+            // Register the same deletions more than once.
+            // This verifies that using a Map to back the deleted records collection prevents duplicate registration.
+            uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1].PricebookEntry.Product2}); // Delete PricebookEntry Product
+            uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1].PricebookEntry}); // Delete PricebookEntry
+            uow.registerDeleted(new List<SObject>{opps[0].OpportunityLineItems[1]}); // Delete OpportunityLine Item
+            uow.commitWork();
+        }
 
-		public Set<Schema.SObjectType> getRegisteredTypes()
-		{
-			return m_registeredTypes.clone();
-		}
+        // Assert Results
+        // TODO: Need to re-instate this check with a better approach, as it is not possible when
+        //       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
+        // System.assertEquals(15, Limits.getDmlStatements());
+        opps = [select Id, Name, (Select Id, PricebookEntry.Product2.Name, Quantity from OpportunityLineItems Order By PricebookEntry.Product2.Name) from Opportunity where Name like 'UoW Test Name %' order by Name];
+        List<Product2> prods = [Select Id from Product2 where Name = 'UoW Test Name 0 Changed : New Product'];
+        System.assertEquals(10, opps.size());
+        System.assertEquals('UoW Test Name 0 Changed', opps[0].Name);
+        System.assertEquals(1, opps[0].OpportunityLineItems.size()); // Should have deleted OpportunityLineItem added above
+        System.assertEquals(0, prods.size()); // Should have deleted Product added above
+    }
 
-		public DerivedUnitOfWork(List<Schema.SObjectType> sObjectTypes)
-		{
-			super(sObjectTypes);
-		}
+    private static void assertResults(String prefix)
+    {
+        // Standard Assertions on tests data inserted by tests
+        String filter = prefix + ' Test Name %';
+        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name like :filter order by Name];
+        System.assertEquals(10, opps.size());
+        System.assertEquals(1, opps[0].OpportunityLineItems.size());
+        System.assertEquals(2, opps[1].OpportunityLineItems.size());
+        System.assertEquals(3, opps[2].OpportunityLineItems.size());
+        System.assertEquals(4, opps[3].OpportunityLineItems.size());
+        System.assertEquals(5, opps[4].OpportunityLineItems.size());
+        System.assertEquals(6, opps[5].OpportunityLineItems.size());
+        System.assertEquals(7, opps[6].OpportunityLineItems.size());
+        System.assertEquals(8, opps[7].OpportunityLineItems.size());
+        System.assertEquals(9, opps[8].OpportunityLineItems.size());
+        System.assertEquals(10, opps[9].OpportunityLineItems.size());
+    }
 
-		public DerivedUnitOfWork(List<Schema.SObjectType> sObjectTypes, IDML dml)
-		{
-			super(sObjectTypes, dml);
-		}
+    /**
+     * Create uow with new records and commit
+     *
+     *	Testing:
+     *
+     *		- Correct events are fired when commitWork completes successfully
+     *
+     */
+    @isTest
+    private static void testDerivedUnitOfWork_CommitSuccess()
+    {
+        // Insert Opporunities with UnitOfWork
+        DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
+        for(Integer o=0; o<10; o++)
+        {
+            Opportunity opp = new Opportunity();
+            opp.Name = 'UoW Test Name ' + o;
+            opp.StageName = 'Open';
+            opp.CloseDate = System.today();
+            uow.registerNew(new List<SObject>{opp});
+            for(Integer i=0; i<o+1; i++)
+            {
+                Product2 product = new Product2();
+                product.Name = opp.Name + ' : Product : ' + i;
+                uow.registerNew(new List<SObject>{product});
+                PricebookEntry pbe = new PricebookEntry();
+                pbe.UnitPrice = 10;
+                pbe.IsActive = true;
+                pbe.UseStandardPrice = false;
+                pbe.Pricebook2Id = Test.getStandardPricebookId();
+                uow.registerNew(pbe, PricebookEntry.Product2Id, product);
+                OpportunityLineItem oppLineItem = new OpportunityLineItem();
+                oppLineItem.Quantity = 1;
+                oppLineItem.TotalPrice = 10;
+                uow.registerRelationship(oppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
+                uow.registerNew(oppLineItem, OpportunityLineItem.OpportunityId, opp);
+            }
+        }
+        uow.commitWork();
 
-		private void addEvent(String event) 
-		{
-			// events should only be fired one time
-			// ensure that this event has not been fired already
-			for (String eventName :m_commitWorkEventsFired)
-			{
-				if (event == eventName)
-				{
-					throw new DerivedUnitOfWorkException(String.format('Event {0} has already been fired.', new List<String> { event }));	
-				}
-			}
-			m_commitWorkEventsFired.add(event);
-		}
+        // Assert Results
+        assertResults('UoW');
 
-		public override void onRegisterType(Schema.SObjectType sObjectType)
-		{
-			if (m_registeredTypes.contains(sObjectType))
-			{
-				throw new DerivedUnitOfWorkException(String.format('Type {0} has already been registered.', new List<String> { sObjectType.getDescribe().getName() }));
-			}
-			m_registeredTypes.add(sObjectType);
-		}
+        assertEvents(new List<String> {
+                'onCommitWorkStarting'
+                , 'onDMLStarting'
+                , 'onDMLFinished'
+                , 'onDoWorkStarting'
+                , 'onDoWorkFinished'
+                , 'onCommitWorkFinishing'
+                , 'onCommitWorkFinished - true'
+            }
+            , uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
+    }
 
-		public override void onCommitWorkStarting()
-		{
-			addEvent('onCommitWorkStarting');
-		}
+    /**
+     * Create uow with data that results in DML Exception
+     *
+     *	Testing:
+     *
+     *		- Correct events are fired when commitWork fails during DML processing
+     *
+     */
+    @isTest
+    private static void testDerivedUnitOfWork_CommitDMLFail()
+    {
+        // Insert Opporunities with UnitOfWork forcing a failure on DML by not setting 'Name' field
+        DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
+        Opportunity opp = new Opportunity();
+        uow.registerNew(new List<SObject>{opp});
+        Boolean didFail = false;
+        System.DmlException caughtEx = null;
 
-		public override void onDMLStarting()
-		{
-			addEvent('onDMLStarting');
-		}
+        try {
+            uow.commitWork();
+        }
+        catch (System.DmlException dmlex) {
+            didFail = true;
+            caughtEx = dmlex;
+        }
 
-		public override void onDMLFinished()
-		{
-			addEvent('onDMLFinished');
-		}		
+        // Assert Results
+        System.assertEquals(didFail, true, 'didFail');
+        System.assert(caughtEx.getMessage().contains('REQUIRED_FIELD_MISSING'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
 
-		public override void onDoWorkStarting()
-		{
-			addEvent('onDoWorkStarting');
-		}
+        assertEvents(new List<String> {
+                'onCommitWorkStarting'
+                , 'onDMLStarting'
+                , 'onCommitWorkFinished - false'
+            }
+            , uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
+    }
 
-		public override void onDoWorkFinished()
-		{
-			addEvent('onDoWorkFinished');
-		}		
+    /**
+     * Create uow with work that fails
+     *
+     *	Testing:
+     *
+     *		- Correct events are fired when commitWork fails during DoWork processing
+     *
+     */
+    @isTest
+    private static void testDerivedUnitOfWork_CommitDoWorkFail()
+    {
+        // Insert Opporunities with UnitOfWork
+        DerivedUnitOfWork uow = new DerivedUnitOfWork(MY_SOBJECTS);
+        Opportunity opp = new Opportunity();
+        opp.Name = 'UoW Test Name 1';
+        opp.StageName = 'Open';
+        opp.CloseDate = System.today();
+        uow.registerNew(new List<SObject>{opp});
 
-		public override void onCommitWorkFinishing()
-		{
-			addEvent('onCommitWorkFinishing');
-		}
+        // register work that will fail during processing
+        FailDoingWork fdw = new FailDoingWork();
+        uow.registerWork(fdw);
 
-		public override void onCommitWorkFinished(Boolean wasSuccessful)
-		{
-			addEvent('onCommitWorkFinished - ' + wasSuccessful);
-		}
-	}
+        Boolean didFail = false;
+        FailDoingWorkException caughtEx = null;
 
-	public class DerivedUnitOfWorkException extends Exception {}
-	public class FailDoingWorkException extends Exception {}
+        try {
+            uow.commitWork();
+        }
+        catch (FailDoingWorkException fdwe) {
+            didFail = true;
+            caughtEx = fdwe;
+        }
+
+        // Assert Results
+        System.assertEquals(didFail, true, 'didFail');
+        System.assert(caughtEx.getMessage().contains('Work failed.'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
+
+        assertEvents(new List<String> {
+                'onCommitWorkStarting'
+                , 'onDMLStarting'
+                , 'onDMLFinished'
+                , 'onDoWorkStarting'
+                , 'onCommitWorkFinished - false'
+            }
+            , uow.getCommitWorkEventsFired(), new Set<Schema.SObjectType>(MY_SOBJECTS), uow.getRegisteredTypes());
+    }
+
+    /**
+     * Assert that actual events exactly match expected events (size, order and name)
+     * and types match expected types
+     */
+    private static void assertEvents(List<String> expectedEvents, List<String> actualEvents, Set<Schema.SObjectType> expectedTypes, Set<Schema.SObjectType> actualTypes)
+    {
+        // assert that events match
+        System.assertEquals(expectedEvents.size(), actualEvents.size(), 'events size');
+        for (Integer i = 0; i < expectedEvents.size(); i++)
+        {
+            System.assertEquals(expectedEvents[i], actualEvents[i], String.format('Event {0} was not fired in order expected.', new List<String> { expectedEvents[i] }));
+        }
+
+        // assert that types match
+        System.assertEquals(expectedTypes.size(), actualTypes.size(), 'types size');
+        for (Schema.SObjectType sObjectType :expectedTypes)
+        {
+            System.assertEquals(true, actualTypes.contains(sObjectType), String.format('Type {0} was not registered.', new List<String> { sObjectType.getDescribe().getName() }));
+        }
+    }
+
+    /**
+     * DoWork implementation that throws exception during processing
+     */
+    private class FailDoingWork implements fflib_SObjectUnitOfWork.IDoWork
+    {
+        public void doWork()
+        {
+            throw new FailDoingWorkException('Work failed.');
+        }
+    }
+
+    /**
+     * Derived unit of work that tracks event notifications and handle registration of type
+     */
+    private class DerivedUnitOfWork extends fflib_SObjectUnitOfWork
+    {
+        private List<String> m_commitWorkEventsFired = new List<String>();
+        private Set<Schema.SObjectType> m_registeredTypes = new Set<Schema.SObjectType>();
+
+        public List<String> getCommitWorkEventsFired()
+        {
+            return m_commitWorkEventsFired.clone();
+        }
+
+        public Set<Schema.SObjectType> getRegisteredTypes()
+        {
+            return m_registeredTypes.clone();
+        }
+
+        public DerivedUnitOfWork(List<Schema.SObjectType> sObjectTypes)
+        {
+            super(sObjectTypes);
+        }
+
+        public DerivedUnitOfWork(List<Schema.SObjectType> sObjectTypes, IDML dml)
+        {
+            super(sObjectTypes, dml);
+        }
+
+        private void addEvent(String event)
+        {
+            // events should only be fired one time
+            // ensure that this event has not been fired already
+            for (String eventName :m_commitWorkEventsFired)
+            {
+                if (event == eventName)
+                {
+                    throw new DerivedUnitOfWorkException(String.format('Event {0} has already been fired.', new List<String> { event }));
+                }
+            }
+            m_commitWorkEventsFired.add(event);
+        }
+
+        public override void onRegisterType(Schema.SObjectType sObjectType)
+        {
+            if (m_registeredTypes.contains(sObjectType))
+            {
+                throw new DerivedUnitOfWorkException(String.format('Type {0} has already been registered.', new List<String> { sObjectType.getDescribe().getName() }));
+            }
+            m_registeredTypes.add(sObjectType);
+        }
+
+        public override void onCommitWorkStarting()
+        {
+            addEvent('onCommitWorkStarting');
+        }
+
+        public override void onDMLStarting()
+        {
+            addEvent('onDMLStarting');
+        }
+
+        public override void onDMLFinished()
+        {
+            addEvent('onDMLFinished');
+        }
+
+        public override void onDoWorkStarting()
+        {
+            addEvent('onDoWorkStarting');
+        }
+
+        public override void onDoWorkFinished()
+        {
+            addEvent('onDoWorkFinished');
+        }
+
+        public override void onCommitWorkFinishing()
+        {
+            addEvent('onCommitWorkFinishing');
+        }
+
+        public override void onCommitWorkFinished(Boolean wasSuccessful)
+        {
+            addEvent('onCommitWorkFinished - ' + wasSuccessful);
+        }
+    }
+
+    public class DerivedUnitOfWorkException extends Exception {}
+    public class FailDoingWorkException extends Exception {}
 }


### PR DESCRIPTION
- Added support to manage the relationship between a Messaging.SingleEmailMessage `whatId` and the related record's id where the related record will be committed as part of the same transaction
- new sections/methods include:
  - void registerRelationship( Messaging.SingleEmailMessage, SObject) method
  - additional code in constructor `fflib_SObjectUnitOfWork(List<Schema.SObjectType>, IDML)` to initialize m_relationships for maintaining email related relationships
  - new overloaded `registerRelationship( Messaging.SingleEmailMessage, SObject)` method
  - addition to the commitWork() method to resolve the email related relationships just prior to the onDMLFinished() method call.
  - introduction of the `fflib_SObjectUnitOfWork.IRelationship` interface
    - this was added to support the ability for each IRelationship type to manage its own "resolving of relationships."
  - Introduction of the `fflib_SObjectUnitOfWork.EmailRelationship` class
  - The`fflib_SObjectUnitOfWork.Relationship` class now implements the IRelationship interface
  - `fflib_SObjectUnitOfWork.Relationships` changes:
    - inner class now works with IRelationship and executes each IRelationship's `resolve()` method.
    - new method `add(Messaging.SingleEmailMessage, SObject)` was added
  - new `fflib_SObjectUnitOfWorkTest.testUnitOfWorkEmail()` method added
- leading tabs were changed to spaces