### PR TITLE
Add the implementation of registerRelationship for SingleEmailMessage…

### DIFF
--- a/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
@@ -52,7 +52,7 @@ public interface fflib_ISObjectUnitOfWork
      * @param a single email message instance
      * @param relatedTo A SOBject instance (yet to be commited to the database)
      */
-    void registerRelationship( Messaging.SingleEmailMessage email, SObject relatedTo );
+    void registerRelationship(Messaging.SingleEmailMessage email, SObject relatedTo);
     /**
      * Register an existing record to be updated during the commitWork method
      *

--- a/fflib/src/classes/fflib_SObjectMocks.cls
+++ b/fflib/src/classes/fflib_SObjectMocks.cls
@@ -71,6 +71,11 @@ public class fflib_SObjectMocks
 			mocks.mockVoidMethod(this, 'registerRelationship', new List<Type> {SObject.class, Schema.sObjectField.class, SObject.class}, new List<Object> {record, relatedToField, relatedTo});
 		}
 
+		public void registerRelationship(Messaging.SingleEmailMessage email, SObject relatedTo)
+		{
+			mocks.mockVoidMethod(this, 'registerRelationship', new List<Type> {Messaging.SingleEmailMessage.class, SObject.class}, new List<Object> {email, relatedTo});
+		}
+
 		public void registerDirty(SObject record)
 		{
 			mocks.mockVoidMethod(this, 'registerDirty', new List<Type> {SObject.class}, new List<Object> {record});


### PR DESCRIPTION
This is is according to the issue reported in #167 which fixes the problem from the new feature in #166. This has been tested by deploying to a brand new Salesforce Developer Org successfully and running full test with 94% test coverage.