### PR TITLE
Added support to the getOrderBy() override to support NULLS LAST setting

### DIFF
--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -420,7 +420,6 @@ public abstract with sharing class fflib_SObjectSelector
         // Parse the getOrderBy()
         for(String orderBy : getOrderBy().split(','))
         {
-            // TODO: Handle NULLS FIRST and NULLS LAST, http://www.salesforce.com/us/developer/docs/soql_sosl/Content/sforce_api_calls_soql_select_orderby.htm
             List<String> orderByParts = orderBy.trim().split(' ');
             String fieldNamePart = orderByParts[0];
             String fieldSortOrderPart = orderByParts.size() > 1 ? orderByParts[1] : null;
@@ -431,7 +430,7 @@ public abstract with sharing class fflib_SObjectSelector
                 fieldSortOrder = fflib_QueryFactory.SortOrder.DESCENDING;
             else if(fieldSortOrderPart.equalsIgnoreCase('ASC'))
                 fieldSortOrder = fflib_QueryFactory.SortOrder.ASCENDING;
-            queryFactory.addOrdering(fieldNamePart, fieldSortOrder);
+            queryFactory.addOrdering(fieldNamePart, fieldSortOrder, orderBy.containsIgnoreCase('NULLS LAST'));
         }           
         
         queryFactory.setSortSelectFields(m_sortSelectFields);           

--- a/fflib/src/classes/fflib_SObjectSelectorTest.cls
+++ b/fflib/src/classes/fflib_SObjectSelectorTest.cls
@@ -151,7 +151,7 @@ private with sharing class fflib_SObjectSelectorTest
 	{
 		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
 		String soql = selector.newQueryFactory().toSOQL();
-		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS FIRST ');
+		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher m = p.matcher(soql);
 		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
@@ -208,12 +208,36 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 
 		//Then
-		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS FIRST ');
+		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		soqlMatcher.matches();
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
 		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+	}
+
+	// Test case of ordering with NULLS LAST option passed into the ordering method
+	@isTest
+	static void testWithOrderingNullsLast()
+	{
+		// Build the selector to test with
+		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector(false, false, false, false);
+		fflib_QueryFactory qf = selector.newQueryFactory();
+		
+		// Add in the expected fields
+		Set<String> expectedSelectFields = new Set<String>{ 'Name', 'Id', 'AccountNumber', 'AnnualRevenue' };
+		if (UserInfo.isMultiCurrencyOrganization())
+		{
+			expectedSelectFields.add('CurrencyIsoCode');
+		}
+
+		// Generate the SOQL string
+		String soql = qf.toSOQL();
+
+		// Assert that the
+		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Matcher soqlMatcher = soqlPattern.matcher(soql);
+		system.assert(soqlMatcher.matches(), 'The SOQL should have that expected.');
 	}
 	
 	private static void assertEqualsSelectFields(String expectedSelectFields, String actualSelectFields)
@@ -253,7 +277,7 @@ private with sharing class fflib_SObjectSelectorTest
 		
 		public override String getOrderBy()
 		{
-			return 'Name DESC, AnnualRevenue ASC';
+			return 'Name DESC, AnnualRevenue ASC NULLS LAST';
 		}
 	}
 	


### PR DESCRIPTION
Pretty simple change to make sure the `getOrderBy()` override in your selector classes support the NULLS LAST setting.