### PR TITLE
Bug #162 - added methods to reset condition, including default

### DIFF
--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -582,10 +582,8 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
 	**/  
     public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction, Boolean nullsLast){
-		setOrdering(
-			new Ordering(getFieldToken(fieldName), direction, nullsLast)
-		);
-		return this;
+		Ordering ordr = new Ordering(getFieldPath(fieldName), direction, nullsLast);
+		return setOrdering(ordr);
     }
 
      /**
@@ -599,11 +597,17 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
 	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
 	**/
+<<<<<<< HEAD
     public fflib_QueryFactory addOrdering(SObjectField field, SortOrder direction){
 		order.add(
 			new Ordering(getFieldTokenPath(field), direction)
 		);	
 		return this;
+=======
+    public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction, Boolean nullsLast){
+		Ordering ordr = new Ordering(field, direction, nullsLast);
+		return setOrdering(ordr);
+>>>>>>> #162: updated setOrderings for methods with string field name parameter
     }
 
     /**
@@ -619,10 +623,8 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
 	**/  
     public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction){
-		setOrdering(
-			new Ordering(getFieldToken(fieldName), direction)
-		);
-		return this;
+		Ordering ordr = new Ordering(getFieldPath(fieldName), direction);
+		return setOrdering(ordr);
     }
 
      /**
@@ -638,10 +640,8 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
 	**/
     public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction){
-		setOrdering(
-			new Ordering(field, direction)
-		);	
-		return this;
+		Ordering ordr = new Ordering(field, direction);	
+		return setOrdering(ordr);
     }
 
 	/**

--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -514,23 +514,6 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		);	
 		return this;
     }
-	/**
-	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
-	 * related through an object lookup or master-detail relationship.
-	 * Use the set to store unique field names, since we only want to sort
-	 * by the same field one time.  The sort expressions are stored in a list
-	 * so that they are applied to the SOQL in the same order that they
-	 * were added in. 
-	 * @param fieldName The string value of the field to be sorted on
-	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
-	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
-	**/  
-    public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction, Boolean nullsLast){
-		order = new List<Ordering> {
-			new Ordering(getFieldToken(fieldName), direction, nullsLast)
-		};	
-		return this;
-    }
 
      /**
 	 * Add a field to be sorted on.  This may be a direct field or a field 
@@ -550,24 +533,6 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		return this;
     }
 
-     /**
-	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
-	 * related through an object lookup or master-detail relationship.
-	 * Use the set to store unique field names, since we only want to sort
-	 * by the same field one time.  The sort expressions are stored in a list
-	 * so that they are applied to the SOQL in the same order that they
-	 * were added in. 
-	 * @param field The SObjectfield to sort.  This can only be a direct reference.
-	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
-	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
-	**/
-    public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction, Boolean nullsLast){
-		order = new List<Ordering> {
-			new Ordering(new QueryField(field), direction, nullsLast)
-		};	
-		return this;
-    }
-
     /**
 	 * Add a field to be sorted on.  This may be a direct field or a field 
 	 * related through an object lookup or master-detail relationship.
@@ -582,27 +547,8 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	**/  
     public fflib_QueryFactory addOrdering(String fieldName, SortOrder direction){
 		order.add(
-			new Ordering(getFieldPath(fieldName), direction)
-		);	
-		return this;
-    }
-
-    /**
-	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
-	 * related through an object lookup or master-detail relationship.
-	 * Use the set to store unique field names, since we only want to sort
-	 * by the same field one time.  The sort expressions are stored in a list
-	 * so that they are applied to the SOQL in the same order that they
-	 * were added in. 
-	 * The "NULLS FIRST" keywords will be included by default.  If "NULLS LAST" 
-	 * is required, use one of the overloaded addOrdering methods which include this parameter.
-	 * @param fieldName The string value of the field to be sorted on
-	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
-	**/  
-    public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction){
-		order = new List<Ordering> {
 			new Ordering(getFieldToken(fieldName), direction)
-		};	
+		);	
 		return this;
     }
 
@@ -620,8 +566,62 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	**/
     public fflib_QueryFactory addOrdering(SObjectField field, SortOrder direction){
 		order.add(
+			new Ordering(getFieldPath(fieldName), direction)
+		);	
+		return this;
+    }
+	/**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	 * related through an object lookup or master-detail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in. 
+	 * @param fieldName The string value of the field to be sorted on
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
+	**/  
+    public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction, Boolean nullsLast){
+		setOrdering(
+			new Ordering(getFieldToken(fieldName), direction, nullsLast)
+		);
+		return this;
+    }
+
+     /**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	 * related through an object lookup or master-detail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in. 
+	 * @param field The SObjectfield to sort.  This can only be a direct reference.
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
+	**/
+    public fflib_QueryFactory addOrdering(SObjectField field, SortOrder direction){
+		order.add(
 			new Ordering(getFieldTokenPath(field), direction)
 		);	
+		return this;
+    }
+
+    /**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	 * related through an object lookup or master-detail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in. 
+	 * The "NULLS FIRST" keywords will be included by default.  If "NULLS LAST" 
+	 * is required, use one of the overloaded addOrdering methods which include this parameter.
+	 * @param fieldName The string value of the field to be sorted on
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	**/  
+    public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction){
+		setOrdering(
+			new Ordering(getFieldToken(fieldName), direction)
+		);
 		return this;
     }
 
@@ -638,9 +638,9 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
 	**/
     public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction){
-		order = new List<Ordering> {
-			new Ordering(new QueryField(field), direction)
-		};	
+		setOrdering(
+			new Ordering(field, direction)
+		);	
 		return this;
     }
 

--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -339,6 +339,13 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		return this;
 	}
 	/**
+	 * @param o an instance of {@link fflib_QueryFactory.Ordering} to remove all existing (for instance defaults) and be added to the query's ORDER BY clause.
+	**/
+	public fflib_QueryFactory setOrdering(Ordering o){
+		this.order = new List<Ordering>{ o };
+		return this;
+	}
+	/**
 	 * @returns the list of orderings that will be used as the query's ORDER BY clause. You may remove elements from the returned list, or otherwise mutate it, to remove previously added orderings.
 	**/
 	public List<Ordering> getOrderings(){
@@ -507,6 +514,23 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		);	
 		return this;
     }
+	/**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	 * related through an object lookup or master-detail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in. 
+	 * @param fieldName The string value of the field to be sorted on
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
+	**/  
+    public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction, Boolean nullsLast){
+		order = new List<Ordering> {
+			new Ordering(getFieldToken(fieldName), direction, nullsLast)
+		};	
+		return this;
+    }
 
      /**
 	 * Add a field to be sorted on.  This may be a direct field or a field 
@@ -523,6 +547,24 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		order.add(
 			new Ordering(getFieldTokenPath(field), direction, nullsLast)
 		);	
+		return this;
+    }
+
+     /**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	 * related through an object lookup or master-detail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in. 
+	 * @param field The SObjectfield to sort.  This can only be a direct reference.
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
+	**/
+    public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction, Boolean nullsLast){
+		order = new List<Ordering> {
+			new Ordering(new QueryField(field), direction, nullsLast)
+		};	
 		return this;
     }
 
@@ -545,6 +587,25 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		return this;
     }
 
+    /**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	 * related through an object lookup or master-detail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in. 
+	 * The "NULLS FIRST" keywords will be included by default.  If "NULLS LAST" 
+	 * is required, use one of the overloaded addOrdering methods which include this parameter.
+	 * @param fieldName The string value of the field to be sorted on
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	**/  
+    public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction){
+		order = new List<Ordering> {
+			new Ordering(getFieldToken(fieldName), direction)
+		};	
+		return this;
+    }
+
      /**
 	 * Add a field to be sorted on.  This may be a direct field or a field 
 	 * related through an object lookup or master-detail relationship.
@@ -561,6 +622,25 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		order.add(
 			new Ordering(getFieldTokenPath(field), direction)
 		);	
+		return this;
+    }
+
+     /**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	 * related through an object lookup or master-detail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in. 
+	 * The "NULLS FIRST" keywords will be included by default.  If "NULLS LAST" 
+	 * is required, use one of the overloaded addOrdering methods which include this parameter.
+	 * @param field The SObjectfield to sort.  This can only be a direct reference.
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	**/
+    public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction){
+		order = new List<Ordering> {
+			new Ordering(new QueryField(field), direction)
+		};	
 		return this;
     }
 

--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -338,9 +338,10 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		this.order.add(o);
 		return this;
 	}
+
 	/**
 	 * @param o an instance of {@link fflib_QueryFactory.Ordering} to remove all existing (for instance defaults) and be added to the query's ORDER BY clause.
-	**/
+	 **/
 	public fflib_QueryFactory setOrdering(Ordering o){
 		this.order = new List<Ordering>{ o };
 		return this;
@@ -547,7 +548,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	**/  
     public fflib_QueryFactory addOrdering(String fieldName, SortOrder direction){
 		order.add(
-			new Ordering(getFieldToken(fieldName), direction)
+			new Ordering(getFieldPath(fieldName), direction)
 		);	
 		return this;
     }
@@ -566,83 +567,72 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	**/
     public fflib_QueryFactory addOrdering(SObjectField field, SortOrder direction){
 		order.add(
-			new Ordering(getFieldPath(fieldName), direction)
-		);	
-		return this;
-    }
-	/**
-	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
-	 * related through an object lookup or master-detail relationship.
-	 * Use the set to store unique field names, since we only want to sort
-	 * by the same field one time.  The sort expressions are stored in a list
-	 * so that they are applied to the SOQL in the same order that they
-	 * were added in. 
-	 * @param fieldName The string value of the field to be sorted on
-	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
-	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
-	**/  
-    public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction, Boolean nullsLast){
-		Ordering ordr = new Ordering(getFieldPath(fieldName), direction, nullsLast);
-		return setOrdering(ordr);
-    }
-
-     /**
-	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
-	 * related through an object lookup or master-detail relationship.
-	 * Use the set to store unique field names, since we only want to sort
-	 * by the same field one time.  The sort expressions are stored in a list
-	 * so that they are applied to the SOQL in the same order that they
-	 * were added in. 
-	 * @param field The SObjectfield to sort.  This can only be a direct reference.
-	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
-	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
-	**/
-<<<<<<< HEAD
-    public fflib_QueryFactory addOrdering(SObjectField field, SortOrder direction){
-		order.add(
 			new Ordering(getFieldTokenPath(field), direction)
 		);	
 		return this;
-=======
-    public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction, Boolean nullsLast){
-		Ordering ordr = new Ordering(field, direction, nullsLast);
-		return setOrdering(ordr);
->>>>>>> #162: updated setOrderings for methods with string field name parameter
     }
 
-    /**
-	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	/**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field
 	 * related through an object lookup or master-detail relationship.
 	 * Use the set to store unique field names, since we only want to sort
 	 * by the same field one time.  The sort expressions are stored in a list
 	 * so that they are applied to the SOQL in the same order that they
-	 * were added in. 
-	 * The "NULLS FIRST" keywords will be included by default.  If "NULLS LAST" 
-	 * is required, use one of the overloaded addOrdering methods which include this parameter.
+	 * were added in.
 	 * @param fieldName The string value of the field to be sorted on
 	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
-	**/  
-    public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction){
-		Ordering ordr = new Ordering(getFieldPath(fieldName), direction);
+	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
+	**/
+	public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction, Boolean nullsLast){
+		Ordering ordr = new Ordering(getFieldPath(fieldName), direction, nullsLast);
 		return setOrdering(ordr);
-    }
+	}
 
-     /**
-	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field 
+	/**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field
+	 * related through an object lookup or masterdetail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in.
+	 * @param field The SObjectfield to sort.  This can only be a direct reference.
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	 * @param nullsLast whether to sort null values last (NULLS LAST keyword included).
+	**/
+	public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction, Boolean nullsLast){
+		Ordering ordr = new Ordering(getFieldTokenPath(field), direction, nullsLast);
+		return setOrdering(ordr);
+	}
+
+	/**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field
 	 * related through an object lookup or master-detail relationship.
 	 * Use the set to store unique field names, since we only want to sort
 	 * by the same field one time.  The sort expressions are stored in a list
 	 * so that they are applied to the SOQL in the same order that they
-	 * were added in. 
-	 * The "NULLS FIRST" keywords will be included by default.  If "NULLS LAST" 
-	 * is required, use one of the overloaded addOrdering methods which include this parameter.
+	 * were added in.
+	 * @param fieldName The string value of the field to be sorted on
+	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
+	**/
+	public fflib_QueryFactory setOrdering(String fieldName, SortOrder direction){
+		Ordering ordr = new Ordering(getFieldPath(fieldName), direction);
+		return setOrdering(ordr);
+	}
+
+	/**
+	 * Remove existing ordering and set a field to be sorted on.  This may be a direct field or a field
+	 * related through an object lookup or masterdetail relationship.
+	 * Use the set to store unique field names, since we only want to sort
+	 * by the same field one time.  The sort expressions are stored in a list
+	 * so that they are applied to the SOQL in the same order that they
+	 * were added in.
 	 * @param field The SObjectfield to sort.  This can only be a direct reference.
 	 * @param SortOrder the direction to be sorted on (ASCENDING or DESCENDING)
 	**/
-    public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction){
-		Ordering ordr = new Ordering(field, direction);	
+	public fflib_QueryFactory setOrdering(SObjectField field, SortOrder direction){
+		Ordering ordr = new Ordering(getFieldTokenPath(field), direction);
 		return setOrdering(ordr);
-    }
+	}
 
 	/**
 	 * Convert the values provided to this instance into a full SOQL string for use with Database.query

--- a/fflib/src/classes/fflib_QueryFactory.cls-meta.xml
+++ b/fflib/src/classes/fflib_QueryFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>42.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -162,40 +162,46 @@ private class fflib_QueryFactoryTest {
 	}
 
 	@isTest
-	static void orderingSet(){
+	static void setOrdering_ReplacesPreviousOrderingsWithExpectedOrdering(){
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.selectField('name');
 		qf.selectField('email');
 		qf.setCondition( 'name = \'test\'' );
-		qf.setOrdering( new fflib_QueryFactory.Ordering('Contact','LastModifiedDate',fflib_QueryFactory.SortOrder.DESCENDING) );
 		
-		System.assertEquals(1,qf.getOrderings().size());
-		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
-
-		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.DESCENDING, true);
+		//test base method with ordeting by OwnerId Descending
+		qf.setOrdering( new fflib_QueryFactory.Ordering('Contact','OwnerId',fflib_QueryFactory.SortOrder.DESCENDING) );
 		
-		System.assertEquals(1,qf.getOrderings().size());
-		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace default Orderings');
+		System.assertEquals(Contact.OwnerId, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field OwnerId');
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
-		qf.setOrdering(Contact.LastModifiedDate, fflib_QueryFactory.SortOrder.DESCENDING, true);
+		//test method overload with ordering by LastModifiedDate Ascending
+		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.ASCENDING, true);
+		
+		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		System.assertEquals(Contact.LastModifiedDate, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field LastModifiedDate');
+		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
-		System.assertEquals(1,qf.getOrderings().size());
-		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+		//test method overload with ordering by CreatedDate Descending
+		qf.setOrdering(Contact.CreatedDate, fflib_QueryFactory.SortOrder.DESCENDING, true);
 
-		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.DESCENDING);
+		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		System.assertEquals(Contact.CreatedDate, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedDate');
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
-		System.assertEquals(1,qf.getOrderings().size());
-		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+		//test method overload with ordering by CreatedBy.Name Descending
+		qf.setOrdering('CreatedBy.Name', fflib_QueryFactory.SortOrder.DESCENDING);
 
-		qf.setOrdering(Contact.LastModifiedDate, fflib_QueryFactory.SortOrder.DESCENDING);
+		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		System.assertEquals(Contact.CreatedById, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedBy.Name');
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
-		System.assertEquals(1,qf.getOrderings().size());
-		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+		//test method overload with ordering by Birthdate Ascending
+		qf.setOrdering(Contact.Birthdate, fflib_QueryFactory.SortOrder.ASCENDING);
+
+		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		System.assertEquals(Contact.Birthdate, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field Birthdate');
+		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		String query = qf.toSOQL();
 	}

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -161,23 +161,23 @@ private class fflib_QueryFactoryTest {
 		System.assert( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
 	}
 
-	@isTest
+	@isTest(isParallel=true)
 	static void setOrdering_ReplacesPreviousOrderingsWithExpectedOrdering(){
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.selectField('name');
 		qf.selectField('email');
 		qf.setCondition( 'name = \'test\'' );
-		
+
 		//test base method with ordeting by OwnerId Descending
 		qf.setOrdering( new fflib_QueryFactory.Ordering('Contact','OwnerId',fflib_QueryFactory.SortOrder.DESCENDING) );
-		
+
 		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace default Orderings');
 		System.assertEquals(Contact.OwnerId.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field OwnerId');
 		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by LastModifiedDate Ascending
 		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.ASCENDING, true);
-		
+
 		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
 		System.assertEquals(Contact.LastModifiedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field LastModifiedDate');
 		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -161,7 +161,7 @@ private class fflib_QueryFactoryTest {
 		System.assert( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
 	}
 
-	@isTest(isParallel=true)
+	@isTest
 	static void setOrdering_ReplacesPreviousOrderingsWithExpectedOrdering(){
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.selectField('name');

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -162,6 +162,45 @@ private class fflib_QueryFactoryTest {
 	}
 
 	@isTest
+	static void orderingSet(){
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField('name');
+		qf.selectField('email');
+		qf.setCondition( 'name = \'test\'' );
+		qf.setOrdering( new fflib_QueryFactory.Ordering('Contact','LastModifiedDate',fflib_QueryFactory.SortOrder.DESCENDING) );
+		
+		System.assertEquals(1,qf.getOrderings().size());
+		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+
+		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.DESCENDING, true);
+		
+		System.assertEquals(1,qf.getOrderings().size());
+		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+
+		qf.setOrdering(Contact.LastModifiedDate, fflib_QueryFactory.SortOrder.DESCENDING, true);
+
+		System.assertEquals(1,qf.getOrderings().size());
+		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+
+		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.DESCENDING);
+
+		System.assertEquals(1,qf.getOrderings().size());
+		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+
+		qf.setOrdering(Contact.LastModifiedDate, fflib_QueryFactory.SortOrder.DESCENDING);
+
+		System.assertEquals(1,qf.getOrderings().size());
+		System.assertEquals(Contact.LastModifiedDate,qf.getOrderings()[0].getField() );
+		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[0].getDirection() );
+
+		String query = qf.toSOQL();
+	}
+
+	@isTest
 	static void invalidField_string(){
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.selectField('name');

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -172,35 +172,34 @@ private class fflib_QueryFactoryTest {
 		qf.setOrdering( new fflib_QueryFactory.Ordering('Contact','OwnerId',fflib_QueryFactory.SortOrder.DESCENDING) );
 		
 		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace default Orderings');
-		System.assertEquals(Contact.OwnerId, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field OwnerId');
+		System.assertEquals(Contact.OwnerId.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field OwnerId');
 		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by LastModifiedDate Ascending
 		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.ASCENDING, true);
 		
 		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.LastModifiedDate, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field LastModifiedDate');
+		System.assertEquals(Contact.LastModifiedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field LastModifiedDate');
 		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by CreatedDate Descending
 		qf.setOrdering(Contact.CreatedDate, fflib_QueryFactory.SortOrder.DESCENDING, true);
 
 		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.CreatedDate, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedDate');
+		System.assertEquals(Contact.CreatedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedDate');
 		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by CreatedBy.Name Descending
 		qf.setOrdering('CreatedBy.Name', fflib_QueryFactory.SortOrder.DESCENDING);
 
 		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.CreatedById, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedBy.Name');
 		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by Birthdate Ascending
 		qf.setOrdering(Contact.Birthdate, fflib_QueryFactory.SortOrder.ASCENDING);
 
 		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.Birthdate, qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field Birthdate');
+		System.assertEquals(Contact.Birthdate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field Birthdate');
 		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		String query = qf.toSOQL();

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls-meta.xml
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>42.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
Workaround for the issue mentioned in enhancement #162.

It allows to set ordering and override existing ordering values that were set by default. 

See below for usage of a new group of ordering setters:


```
String query = newQueryFactory()
		.setOrdering('BillingState', fflib_QueryFactory.SortOrder.ASCENDING)
                .addOrdering('Name', fflib_QueryFactory.SortOrder.ASCENDING)
		.toSOQL();
```