### PR TITLE
Feature/uow register dirty fields

### DIFF
--- a/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
@@ -60,6 +60,16 @@ public interface fflib_ISObjectUnitOfWork
      **/
     void registerDirty(SObject record);
     /**
+     * Register specific fields on record to be updated when work is commited
+     *
+     * If the record has previously been registered as dirty, the dirty fields on the record in this call will overwrite
+     * the values of the previously registered dirty record
+     *
+     * @param record An existing record
+     * @param dirtyFields The fields to update if record is already registered
+     **/
+    void registerDirty(SObject record, List<SObjectField> dirtyFields);
+    /**
      * Register an existing record to be updated when commitWork is called,
      *   you may also provide a reference to the parent record instance (should also be registered as new separatly)
      *

--- a/fflib/src/classes/fflib_SObjectMocks.cls
+++ b/fflib/src/classes/fflib_SObjectMocks.cls
@@ -81,6 +81,15 @@ public class fflib_SObjectMocks
 			mocks.mockVoidMethod(this, 'registerDirty', new List<Type> {SObject.class}, new List<Object> {record});
 		}
 
+		public void registerDirty(SObject record, List<SObjectField> dirtyFields)
+		{
+			mocks.mockVoidMethod(this, 'registerDirty', new List<Type> {
+					SObject.class, System.Type.forName('List<SObjectField>')
+			}, new List<Object> {
+					record, dirtyFields
+			});
+		}
+
         public void registerDirty(SObject record, Schema.sObjectField relatedToParentField, SObject relatedToParentRecord)
         {
             mocks.mockVoidMethod(this, 'registerDirty', new List<Type> {SObject.class}, new List<Object> {record});

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -270,13 +270,6 @@ public virtual class fflib_SObjectUnitOfWork
             // Update the registered record's fields
             SObject registeredRecord = m_dirtyMapByType.get(sObjectType).get(record.Id);
 
-            // If the caller has supplied a different instance of the same record with no list of updated fields
-            if (dirtyFields.isEmpty() && registeredRecord !== record)
-            {
-                // Cannot determine what updates to make to the record (assuming updating nothing is incorrect)
-                throw new UnitOfWorkException('Cannot determine what fields to update on record ' + record);
-            }
-
             for (SObjectField dirtyField : dirtyFields) {
                 registeredRecord.put(dirtyField, record.get(dirtyField));
             }

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -259,7 +259,7 @@ public virtual class fflib_SObjectUnitOfWork
         if(!m_dirtyMapByType.containsKey(sObjectType))
             throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
 
-        // If record isn't registered as dirty
+        // If record isn't registered as dirty, or no dirty fields to drive a merge
         if (!m_dirtyMapByType.get(sObjectType).containsKey(record.Id) || dirtyFields.isEmpty())
         {
             // Register the record as dirty

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -260,7 +260,7 @@ public virtual class fflib_SObjectUnitOfWork
             throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
 
         // If record isn't registered as dirty
-        if (!m_dirtyMapByType.get(sObjectType).containsKey(record.Id))
+        if (!m_dirtyMapByType.get(sObjectType).containsKey(record.Id) || dirtyFields.isEmpty())
         {
             // Register the record as dirty
             m_dirtyMapByType.get(sObjectType).put(record.Id, record);

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -248,11 +248,40 @@ public virtual class fflib_SObjectUnitOfWork
      **/
     public void registerDirty(SObject record)
     {
+        registerDirty(record, new List<SObjectField>());
+    }
+
+    public void registerDirty(SObject record, List<SObjectField> dirtyFields)
+    {
         if(record.Id == null)
             throw new UnitOfWorkException('New records cannot be registered as dirty');
         String sObjectType = record.getSObjectType().getDescribe().getName();
         if(!m_dirtyMapByType.containsKey(sObjectType))
             throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
+
+        // If record isn't registered as dirty
+        if (!m_dirtyMapByType.get(sObjectType).containsKey(record.Id))
+        {
+            // Register the record as dirty
+            m_dirtyMapByType.get(sObjectType).put(record.Id, record);
+        }
+        else
+        {
+            // Update the registered record's fields
+            SObject registeredRecord = m_dirtyMapByType.get(sObjectType).get(record.Id);
+
+            // If the caller has supplied a different instance of the same record with no list of updated fields
+            if (dirtyFields.isEmpty() && registeredRecord !== record)
+            {
+                // Cannot determine what updates to make to the record (assuming updating nothing is incorrect)
+                throw new UnitOfWorkException('Cannot determine what fields to update on record ' + record);
+            }
+
+            for (SObjectField dirtyField : dirtyFields) {
+                registeredRecord.put(dirtyField, record.get(dirtyField));
+            }
+        }
+
         m_dirtyMapByType.get(sObjectType).put(record.Id, record);
     }
 

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -280,9 +280,9 @@ public virtual class fflib_SObjectUnitOfWork
             for (SObjectField dirtyField : dirtyFields) {
                 registeredRecord.put(dirtyField, record.get(dirtyField));
             }
-        }
 
-        m_dirtyMapByType.get(sObjectType).put(record.Id, record);
+            m_dirtyMapByType.get(sObjectType).put(record.Id, registeredRecord);
+        }
     }
 
     /**

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -339,27 +339,27 @@ private with sharing class fflib_SObjectUnitOfWorkTest
     }
 
     /**
-     * Try registering two instances of the same record as dirty.
+     * Try registering two instances of the same record as dirty. Second register should overwrite first.
      *
      *  Testing:
      *
      *      - Exception is thrown stopping second registration
      */
     @isTest
-    private static void testRegisterDirty_DoubleException() {
-        Opportunity opp = new Opportunity(Id = '00636000005loIj', Name = 'UpdateName');
-        Opportunity opp2 = new Opportunity(Id = '00636000005loIj', Amount = 250);
+    private static void testRegisterDirty_ExpectReplacement() {
+        final Opportunity insertedOpp = new Opportunity(Name = 'Original', StageName = 'Open', CloseDate = System.today());
+        insert insertedOpp;
+
+        Opportunity opp = new Opportunity(Id = insertedOpp.Id, Name = 'Never');
+        Opportunity opp2 = new Opportunity(Id = insertedOpp.Id, Name = 'Expected');
+
         fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
         uow.registerDirty(opp);
-        Boolean exceptionThrown = false;
-        try {
-            // Second registration would undo updates of first registration
-            uow.registerDirty(opp2);
-        } catch (fflib_SObjectUnitOfWork.UnitOfWorkException e) {
-            System.assert(e.getMessage().contains(opp.Id));
-            exceptionThrown = true;
-        }
-        System.assert(exceptionThrown);
+        uow.registerDirty(opp2);
+        uow.commitWork();
+
+        Opportunity updated = [select Id, Name from Opportunity where Id = :insertedOpp.Id];
+        System.assertEquals('Expected', updated.Name);
     }
 
     /**
@@ -381,7 +381,7 @@ private with sharing class fflib_SObjectUnitOfWorkTest
         uow.registerDirty(amountUpdate, new List<SObjectField> { Opportunity.Amount } );
         uow.commitWork();
 
-        opp = [SELECT Name, Amount FROM Opportunity WHERE Id = :opp.Id];
+        opp = [select Name, Amount from Opportunity where Id = :opp.Id];
         System.assertEquals(opp.Name, nameUpdate.Name);
         System.assertEquals(opp.Amount, amountUpdate.Amount);
     }

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -349,13 +349,13 @@ private with sharing class fflib_SObjectUnitOfWorkTest
     private static void testRegisterDirty_DoubleException() {
         Opportunity opp = new Opportunity(Id = '00636000005loIj', Name = 'UpdateName');
         Opportunity opp2 = new Opportunity(Id = '00636000005loIj', Amount = 250);
-        UnitOfWork uow = new UnitOfWork(MY_SOBJECTS);
+        fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
         uow.registerDirty(opp);
         Boolean exceptionThrown = false;
         try {
             // Second registration would undo updates of first registration
             uow.registerDirty(opp2);
-        } catch (UnitOfWork.UnitOfWorkException e) {
+        } catch (fflib_SObjectUnitOfWork.UnitOfWorkException e) {
             System.assert(e.getMessage().contains(opp.Id));
             exceptionThrown = true;
         }
@@ -376,38 +376,14 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 
         Opportunity nameUpdate = new Opportunity(Id = opp.Id, Name = 'UpdateName');
         Opportunity amountUpdate = new Opportunity(Id = opp.Id, Amount = 250);
-        UnitOfWork uow = new UnitOfWork(MY_SOBJECTS);
+        fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
         uow.registerDirty(nameUpdate);
-        uow.registerDirty(amountUpdate, Opportunity.Amount);
+        uow.registerDirty(amountUpdate, new List<SObjectField> { Opportunity.Amount } );
         uow.commitWork();
 
         opp = [SELECT Name, Amount FROM Opportunity WHERE Id = :opp.Id];
         System.assertEquals(opp.Name, nameUpdate.Name);
         System.assertEquals(opp.Amount, amountUpdate.Amount);
-    }
-
-    /**
-     * Try registering a single unupdateable field as dirty in secure mode
-     *
-     *  Testing:
-     *
-     *      - exception is thrown
-     */
-    @isTest
-    private static void testRegisterDirty_field_secure() {
-        Opportunity opp = new Opportunity(Name = 'test name', StageName = 'Open', CloseDate = System.today());
-        insert opp;
-
-        UnitOfWork uow = new UnitOfWork(MY_SOBJECTS, new AccessConfig());
-        uow.registerDirty(opp, Opportunity.Id); // Should throw exception because ID is not updatable
-
-        Boolean exceptionThrown = false;
-        try {
-            uow.commitWork();
-        } catch (fflib_SecurityUtils.SecurityException e) {
-            exceptionThrown = true;
-        }
-        System.assert(exceptionThrown);
     }
 
     /**

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -339,6 +339,78 @@ private with sharing class fflib_SObjectUnitOfWorkTest
     }
 
     /**
+     * Try registering two instances of the same record as dirty.
+     *
+     *  Testing:
+     *
+     *      - Exception is thrown stopping second registration
+     */
+    @isTest
+    private static void testRegisterDirty_DoubleException() {
+        Opportunity opp = new Opportunity(Id = '00636000005loIj', Name = 'UpdateName');
+        Opportunity opp2 = new Opportunity(Id = '00636000005loIj', Amount = 250);
+        UnitOfWork uow = new UnitOfWork(MY_SOBJECTS);
+        uow.registerDirty(opp);
+        Boolean exceptionThrown = false;
+        try {
+            // Second registration would undo updates of first registration
+            uow.registerDirty(opp2);
+        } catch (UnitOfWork.UnitOfWorkException e) {
+            System.assert(e.getMessage().contains(opp.Id));
+            exceptionThrown = true;
+        }
+        System.assert(exceptionThrown);
+    }
+
+    /**
+     * Try registering a single field as dirty.
+     *
+     *  Testing:
+     *
+     *      - field is updated
+     */
+    @isTest
+    private static void testRegisterDirty_field() {
+        Opportunity opp = new Opportunity(Name = 'test name', StageName = 'Open', CloseDate = System.today());
+        insert opp;
+
+        Opportunity nameUpdate = new Opportunity(Id = opp.Id, Name = 'UpdateName');
+        Opportunity amountUpdate = new Opportunity(Id = opp.Id, Amount = 250);
+        UnitOfWork uow = new UnitOfWork(MY_SOBJECTS);
+        uow.registerDirty(nameUpdate);
+        uow.registerDirty(amountUpdate, Opportunity.Amount);
+        uow.commitWork();
+
+        opp = [SELECT Name, Amount FROM Opportunity WHERE Id = :opp.Id];
+        System.assertEquals(opp.Name, nameUpdate.Name);
+        System.assertEquals(opp.Amount, amountUpdate.Amount);
+    }
+
+    /**
+     * Try registering a single unupdateable field as dirty in secure mode
+     *
+     *  Testing:
+     *
+     *      - exception is thrown
+     */
+    @isTest
+    private static void testRegisterDirty_field_secure() {
+        Opportunity opp = new Opportunity(Name = 'test name', StageName = 'Open', CloseDate = System.today());
+        insert opp;
+
+        UnitOfWork uow = new UnitOfWork(MY_SOBJECTS, new AccessConfig());
+        uow.registerDirty(opp, Opportunity.Id); // Should throw exception because ID is not updatable
+
+        Boolean exceptionThrown = false;
+        try {
+            uow.commitWork();
+        } catch (fflib_SecurityUtils.SecurityException e) {
+            exceptionThrown = true;
+        }
+        System.assert(exceptionThrown);
+    }
+
+    /**
      * Assert that actual events exactly match expected events (size, order and name)
      * and types match expected types
      */


### PR DESCRIPTION
Introduces merge functionality on registerDirty via a collection of SObjectFields parameter. 

Removes breaking change that existed in previous pull request for this feature.

As Travis isn't playing nice, below is the result of the unit tests;

![tests](https://i.imgur.com/bvy9kGA.png)

