### PR TITLE
Add custom dml for Application.UnitOfWork.newInstance call

### DIFF
--- a/fflib/src/classes/fflib_Application.cls
+++ b/fflib/src/classes/fflib_Application.cls
@@ -62,8 +62,23 @@ public class fflib_Application
 			return new fflib_SObjectUnitOfWork(m_objectTypes);
 		}
 
+
 		/**
-		 * Returns a new fflib_SObjectUnitOfWork configured with the 
+		 * Returns a new fflib_SObjectUnitOfWork configured with the
+		 *   SObjectType list provided in the constructor, returns a Mock implementation
+		 *   if set via the setMock method
+		 **/
+		public fflib_ISObjectUnitOfWork newInstance(fflib_SObjectUnitOfWork.IDML dml)
+		{
+			// Mock?
+			if(m_mockUow!=null)
+				return m_mockUow;
+			return new fflib_SObjectUnitOfWork(m_objectTypes, dml);
+		}
+
+
+		/**
+		 * Returns a new fflib_SObjectUnitOfWork configured with the
 		 *   SObjectType list specified, returns a Mock implementation
 		 *   if set via the setMock method
 		 *
@@ -77,6 +92,23 @@ public class fflib_Application
 				return m_mockUow;
 			return new fflib_SObjectUnitOfWork(objectTypes);
 		}		
+
+		/**
+		 * Returns a new fflib_SObjectUnitOfWork configured with the
+		 *   SObjectType list specified, returns a Mock implementation
+		 *   if set via the setMock method
+		 *
+		 * @remark If mock is set, the list of SObjectType in the mock could be different
+		 *         then the list of SObjectType specified in this method call
+		 **/
+		public fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes, fflib_SObjectUnitOfWork.IDML dml)
+		{
+			// Mock?
+			if(m_mockUow!=null)
+				return m_mockUow;
+			return new fflib_SObjectUnitOfWork(objectTypes, dml);
+		}
+
 
 		@TestVisible
 		private void setMock(fflib_ISObjectUnitOfWork mockUow)

--- a/fflib/src/classes/fflib_ApplicationTest.cls
+++ b/fflib/src/classes/fflib_ApplicationTest.cls
@@ -213,6 +213,23 @@ private class fflib_ApplicationTest
 	}
 
 	@IsTest
+	private static void callingUnitOfWorkFactoryWithCustomTypesShouldGivenStandardImplsAndMockImpls()
+	{
+		// Standard behaviour
+		System.assert(
+				UnitOfWork.newInstance(
+						new List<SObjectType>{ Account.SObjectType}
+				) instanceof fflib_SObjectUnitOfWork);
+
+		// Mocking behaviour
+		UnitOfWork.setMock(new fflib_SObjectMocks.SObjectUnitOfWork(new fflib_ApexMocks()));
+		System.assert(
+				UnitOfWork.newInstance(
+						new List<SObjectType>{ Account.SObjectType}
+				) instanceof fflib_SObjectMocks.SObjectUnitOfWork);
+	}
+
+	@IsTest
 	private static void callingServiceFactoryShouldGiveRegisteredImplsAndMockImpls()
 	{
 		// Standard behaviour
@@ -348,6 +365,96 @@ private class fflib_ApplicationTest
 		System.assert(Selector.newInstance(Opportunity.SObjectType) instanceof OpportuntiesSelector);
 	}
 
+
+	@IsTest
+	private static void callingUnitOfWorkWithCustomDML()
+	{
+		// Given a custom DML class and a new record
+		CustomDML customDML = new CustomDML();
+		Account myAccount = new Account(Name = 'Test Account');
+
+		// When the unit of work is instantiated from the Application Class and the record is registered and commited
+		fflib_ISObjectUnitOfWork unitOfWork = UnitOfWork.newInstance(customDML);
+		unitOfWork.registerNew(myAccount);
+		unitOfWork.commitWork();
+
+		// Then the Custom DML is used by the unit of Work
+		System.assert(customDML.isInsertCalled, 'Oops, custom DML was not called');
+	}
+
+	@IsTest
+	private static void callingMockedUnitOfWorkWithCustomDML()
+	{
+		// Given a custom DML class and a new record
+		CustomDML customDML = new CustomDML();
+		Account myAccount = new Account(Name = 'Test Account');
+
+		// When the unit of work is instantiated from the Application Class and the record is registered and commited
+		UnitOfWork.setMock(new fflib_SObjectMocks.SObjectUnitOfWork(new fflib_ApexMocks()));
+		fflib_ISObjectUnitOfWork uow = UnitOfWork.newInstance(customDML);
+
+		uow.registerNew(myAccount);
+		uow.commitWork();
+
+		// Then the Custom DML should not be used by the unit of Work
+		System.assert(!customDML.isInsertCalled, 'Oops, custom DML was called');
+	}
+
+	@IsTest
+	private static void callingUnitOfWorkWithCustomObjectTypesAndDML()
+	{
+		// Given a custom DML class and a new record
+		CustomDML customDML = new CustomDML();
+		Account myAccount = new Account(Name = 'Test Account');
+
+		// When the unit of work is instantiated from the Application Class and the record is registered and commited
+		fflib_ISObjectUnitOfWork unitOfWork = UnitOfWork.newInstance(
+				new List<SObjectType>{ Account.SObjectType },
+				customDML
+		);
+		unitOfWork.registerNew(myAccount);
+		unitOfWork.commitWork();
+
+		// Then the Custom DML is used by the unit of Work
+		System.assert(customDML.isInsertCalled, 'Oops, custom DML was not called');
+	}
+
+	@IsTest
+	private static void callingMockedUnitOfWorkWithCustomObjectTypesAndDML()
+	{
+		// Given a custom DML class and a new record
+		CustomDML customDML = new CustomDML();
+		Account myAccount = new Account(Name = 'Test Account');
+
+		// When the unit of work is instantiated from the Application Class and the record is registered and commited
+		UnitOfWork.setMock(new fflib_SObjectMocks.SObjectUnitOfWork(new fflib_ApexMocks()));
+		fflib_ISObjectUnitOfWork uow = UnitOfWork.newInstance(
+				new List<SObjectType>{ Account.SObjectType },
+				customDML
+		);
+		uow.registerNew(myAccount);
+		uow.commitWork();
+
+		// Then the Custom DML should not be used by the unit of Work
+		System.assert(!customDML.isInsertCalled, 'Oops, custom DML was called');
+	}
+
+	public class CustomDML implements fflib_SObjectUnitOfWork.IDML
+	{
+		public boolean isInsertCalled = false;
+		public boolean isUpdateCalled = false;
+		public boolean isDeleteCalled = false;
+
+		public void dmlInsert(List<SObject> objList){
+			this.isInsertCalled = true;
+		}
+		public void dmlUpdate(List<SObject> objList){
+			this.isUpdateCalled = true;
+		}
+		public void dmlDelete(List<SObject> objList){
+			this.isDeleteCalled = true;
+		}
+	}
 
 	// Configure and create the ServiceFactory for this Application
 	public static final fflib_Application.ServiceFactory Service = 


### PR DESCRIPTION
When you create an instance of fflib_SObjectUnitOfWork there is an extra parameter in the constructor to pass in a custom DML (instance of fflib_SObjectUnitOfWork.IDML) instead of using the standard fflib_SObjectUnitOfWork.SimpleDML.

But when you want to call the UnitOfWork directly from the Application class, then there was no option to pass a custom DML class. 

This pull-request adds that functionality.