### PR TITLE
Add Identity Map design pattern

### DIFF
--- a/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_ISObjectUnitOfWork.cls
@@ -14,6 +14,50 @@
  **/
 public interface fflib_ISObjectUnitOfWork
 {
+     /**
+     * Register a just queried SObject that has not been changed yet
+     *
+     * @param record A queried SObject instance
+     **/
+	void registerClean(SObject record);
+	/**
+     * Register a list of just queried SObject that has not been changed yet
+     *
+     * @param records A list of queried SObject instances
+     **/
+	void registerClean(List<SObject> records);
+	/**
+	 * Get clean registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	Map<Id, SObject> getClean(String sObjectType, Set<Id> idSet);
+    Map<Id, SObject> getClean(Schema.SObjectType sObjectType, Set<Id> idSet);
+	/**
+	 * Get dirty registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	Map<Id, SObject> getDirty(String sObjectType, Set<Id> idSet);
+	Map<Id, SObject> getDirty(Schema.SObjectType sObjectType, Set<Id> idSet);
+	/**
+	 * Get deleted registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	Map<Id, SObject> getDeleted(String sObjectType, Set<Id> idSet);
+	Map<Id, SObject> getDeleted(Schema.SObjectType sObjectType, Set<Id> idSet);
+	/**
+     * Get Ids of deleted registered records
+     *
+     * @param sObjectType
+     * @param idSet A set of Id's to search for
+     */
+	Set<Id> getDeletedIds(String sObjectType, Set<Id> idSet);
+	Set<Id> getDeletedIds(Schema.SObjectType sObjectType, Set<Id> idSet);
     /**
      * Register a newly created SObject instance to be inserted when commitWork is called
      *

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -58,6 +58,8 @@ public virtual class fflib_SObjectUnitOfWork
 
     protected Map<String, List<SObject>> m_newListByType = new Map<String, List<SObject>>();
 
+	protected Map<String, Map<Id, SObject>> m_cleanMapByType = new Map<String, Map<Id, SObject>>();
+
     protected Map<String, Map<Id, SObject>> m_dirtyMapByType = new Map<String, Map<Id, SObject>>();
 
     protected Map<String, Map<Id, SObject>> m_deletedMapByType = new Map<String, Map<Id, SObject>>();
@@ -145,6 +147,7 @@ public virtual class fflib_SObjectUnitOfWork
     {
         // add type to dml operation tracking
         m_newListByType.put(sObjectType.getDescribe().getName(), new List<SObject>());
+	    m_cleanMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
         m_dirtyMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
         m_deletedMapByType.put(sObjectType.getDescribe().getName(), new Map<Id, SObject>());
         m_relationships.put(sObjectType.getDescribe().getName(), new Relationships());
@@ -168,6 +171,69 @@ public virtual class fflib_SObjectUnitOfWork
     {
         m_emailWork.registerEmail(email);
     }
+
+	/**
+	 * Register a list of just queried SObject that has not been changed yet
+	 *
+	 * @param records A list of queried SObject instances
+	 **/
+	public void registerClean(List<SObject> records)
+	{
+		for (SObject record : records)
+		{
+			registerClean(record);
+		}
+	}
+
+	/**
+	 * Register a just queried SObject that has not been changed yet
+	 *
+	 * @param record A queried SObject instance
+	 **/
+	public void registerClean(SObject record)
+	{
+		if (null == record.Id)
+		{
+			throw new UnitOfWorkException('Only existing records can be registered as clean');
+		}
+		String sObjectType = record.getSObjectType().getDescribe().getName();
+		if (!m_cleanMapByType.containsKey(sObjectType))
+		{
+			throw new UnitOfWorkException(
+					String.format(
+							'SObject type {0} is not supported by this unit of work',
+							new String[] {sObjectType}
+					)
+			);
+		}
+
+		// If record is already registered as clean, see if we have additional fields to store
+		if (m_cleanMapByType.get(sObjectType).containsKey(record.Id))
+		{
+			// Search for additional fields
+			SObject cleanRecord = m_cleanMapByType.get(sObjectType).get(record.Id);
+			Set<String> cleanRecordFields = cleanRecord.getPopulatedFieldsAsMap().keySet();
+			Map<String, Object> valueToFieldNameMap = record.getPopulatedFieldsAsMap();
+			for (String fieldName : valueToFieldNameMap.keySet())
+			{
+				// If field value is changed or field doesn't exists on clean record
+				if (
+						(cleanRecordFields.contains(fieldName) && (cleanRecord.get(fieldName) != record.get(fieldName)))
+								||
+								!cleanRecordFields.contains(fieldName)
+						)
+				{
+					// Store field value in clean record
+					cleanRecord.put(fieldName, valueToFieldNameMap.get(fieldName));
+				}
+			}
+		}
+		else
+		{
+			// Register the record as clean by storing a clone.
+			m_cleanMapByType.get(sObjectType).put(record.Id, record.clone(true, true, true, true));
+		}
+	}
 
     /**
      * Register a newly created SObject instance to be inserted when commitWork is called
@@ -251,6 +317,12 @@ public virtual class fflib_SObjectUnitOfWork
         registerDirty(record, new List<SObjectField>());
     }
 
+	/**
+	 * Register an existing record to be updated during the commitWork method
+	 *
+	 * @param record An existing record
+	 * @param dirtyFields Only the fields in this list should be registered
+	 **/
     public void registerDirty(SObject record, List<SObjectField> dirtyFields)
     {
         if(record.Id == null)
@@ -259,24 +331,27 @@ public virtual class fflib_SObjectUnitOfWork
         if(!m_dirtyMapByType.containsKey(sObjectType))
             throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
 
-        // If record isn't registered as dirty, or no dirty fields to drive a merge
-        if (!m_dirtyMapByType.get(sObjectType).containsKey(record.Id) || dirtyFields.isEmpty())
+        // If the record is already registered as dirty and a list of dirty fields is provided
+        if (m_dirtyMapByType.get(sObjectType).containsKey(record.Id) && !dirtyFields.isEmpty())
         {
+	        // Update the provided fields on the register record
+	        registerDirtyFields(sObjectType, record, dirtyFields);
+        }
+	    // else if the record is already registered as dirty, a clean version exists and no dirty fields to drive a merge
+	    else if (m_dirtyMapByType.get(sObjectType).containsKey(record.Id)
+			    && dirtyFields.isEmpty()
+			    && m_cleanMapByType.get(sObjectType).containsKey(record.Id))
+	    {
+		    // compare clean and dirty and only register the changes
+		    registerDirtyFieldsOnly(sObjectType, m_cleanMapByType.get(sObjectType).get(record.Id), record);
+	    }
+	    else
+	    {
             // Register the record as dirty
             m_dirtyMapByType.get(sObjectType).put(record.Id, record);
         }
-        else
-        {
-            // Update the registered record's fields
-            SObject registeredRecord = m_dirtyMapByType.get(sObjectType).get(record.Id);
-
-            for (SObjectField dirtyField : dirtyFields) {
-                registeredRecord.put(dirtyField, record.get(dirtyField));
-            }
-
-            m_dirtyMapByType.get(sObjectType).put(record.Id, registeredRecord);
-        }
     }
+
 
     /**
      * Register an existing record to be updated when commitWork is called,
@@ -288,12 +363,7 @@ public virtual class fflib_SObjectUnitOfWork
      **/
     public void registerDirty(SObject record, Schema.sObjectField relatedToParentField, SObject relatedToParentRecord)
     {
-        if(record.Id == null)
-            throw new UnitOfWorkException('New records cannot be registered as dirty');
-        String sObjectType = record.getSObjectType().getDescribe().getName();
-        if(!m_dirtyMapByType.containsKey(sObjectType))
-            throw new UnitOfWorkException(String.format('SObject type {0} is not supported by this unit of work', new String[] { sObjectType }));
-        m_dirtyMapByType.get(sObjectType).put(record.Id, record);
+	    registerDirty(record);
         if(relatedToParentRecord!=null && relatedToParentField!=null)
             registerRelationship(record, relatedToParentField, relatedToParentRecord);
     }
@@ -310,6 +380,59 @@ public virtual class fflib_SObjectUnitOfWork
             this.registerDirty(record);
         }
     }
+
+	/**
+	 * Register only changed fields by comparing clean and dirty, to be updated during the commitWork method
+	 *
+	 * @param sObjectType The SObjectType of the record to process
+	 * @param cleanRecord The clean record
+	 * @param dirtyRecord The dirty record
+	 **/
+	private void registerDirtyFieldsOnly(String sObjectType, SObject cleanRecord, SObject dirtyRecord)
+	{
+		List<SObjectField> dirtyFields = new List<SObjectField>();
+		Map<String, Object> cleanRecordFieldsAsMap = cleanRecord.getPopulatedFieldsAsMap();
+		Map<String, Object> dirtyRecordFieldsAsMap = dirtyRecord.getPopulatedFieldsAsMap();
+
+		Map<String, SObjectField> fieldDescribe = dirtyRecord.getSObjectType().getDescribe().fields.getMap();
+		for (String field : dirtyRecordFieldsAsMap.keySet())
+		{
+			// field exists on clean record and values are different, or field does not exist on clean record
+			if (
+					(cleanRecordFieldsAsMap.containsKey(field) && (cleanRecordFieldsAsMap.get(field) != dirtyRecordFieldsAsMap.get(field)))
+							||
+					(!cleanRecordFieldsAsMap.containsKey(field))
+			   )
+			{
+				dirtyFields.add(fieldDescribe.get(field));
+			}
+		}
+
+		if (!dirtyFields.isEmpty())
+		{
+			registerDirtyFields(sObjectType, dirtyRecord, dirtyFields);
+		}
+	}
+
+	/**
+	 * Register only changed fields to be updated during the commitWork method
+	 *
+	 * @param sObjectType The SObjectType of the record to process
+	 * @param record An existing record
+	 * @param dirtyFields Only the fields in this list should be registered
+	 **/
+	private void registerDirtyFields(String sObjectType, sObject record, List<SObjectField> dirtyFields)
+	{
+		// Update the registered record's fields
+		SObject registeredRecord = m_dirtyMapByType.get(sObjectType).get(record.Id);
+
+		for (SObjectField dirtyField : dirtyFields)
+		{
+			registeredRecord.put(dirtyField, record.get(dirtyField));
+		}
+
+		m_dirtyMapByType.get(sObjectType).put(record.Id, registeredRecord);
+	}
 
     /**
      * Register an existing record to be deleted during the commitWork method
@@ -338,6 +461,124 @@ public virtual class fflib_SObjectUnitOfWork
             this.registerDeleted(record);
         }
     }
+
+	/**
+	 * Get clean registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	public Map<Id, SObject> getClean(Schema.SObjectType sObjectType, Set<Id> idSet)
+	{
+		return getClean(sObjectType.getDescribe().getName(), idSet);
+	}
+
+	/**
+	 * Get clean registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	public Map<Id, SObject> getClean(String sObjectType, Set<Id> idSet)
+	{
+		if (m_cleanMapByType.containsKey(sObjectType))
+		{
+			return retainAllInMap(m_cleanMapByType.get(sObjectType), idSet);
+		}
+		else
+		{
+			return new Map<Id, SObject>();
+		}
+	}
+
+	/**
+	 * Get dirty registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	public Map<Id, SObject> getDirty(Schema.SObjectType sObjectType, Set<Id> idSet)
+	{
+		return getDirty(sObjectType.getDescribe().getName(), idSet);
+	}
+
+	/**
+	 * Get dirty registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	public Map<Id, SObject> getDirty(String sObjectType, Set<Id> idSet)
+	{
+		if (m_dirtyMapByType.containsKey(sObjectType))
+		{
+			return retainAllInMap(m_dirtyMapByType.get(sObjectType), idSet);
+		}
+		else
+		{
+			return new Map<Id, SObject>();
+		}
+	}
+
+	/**
+	 * Get deleted registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	public Map<Id, SObject> getDeleted(Schema.SObjectType sObjectType, Set<Id> idSet)
+	{
+		return getDeleted(sObjectType.getDescribe().getName(), idSet);
+	}
+
+	/**
+	 * Get deleted registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	 */
+	public Map<Id, SObject> getDeleted(String sObjectType, Set<Id> idSet)
+	{
+		if (m_deletedMapByType.containsKey(sObjectType))
+		{
+			return retainAllInMap(m_deletedMapByType.get(sObjectType), idSet);
+		}
+		else
+		{
+			return new Map<Id, SObject>();
+		}
+	}
+
+	/**
+	 * Get Ids of deleted registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	*/
+	public Set<Id> getDeletedIds(Schema.SObjectType sObjectType, Set<Id> idSet)
+	{
+		return getDeletedIds(sObjectType.getDescribe().getName(), idSet);
+	}
+
+	/**
+	 * Get Ids of deleted registered records
+	 *
+	 * @param sObjectType
+	 * @param idSet A set of Id's to search for
+	*/
+	public Set<Id> getDeletedIds(String sObjectType, Set<Id> idSet)
+	{
+		if (m_deletedMapByType.containsKey(sObjectType))
+		{
+			Set<Id> recordIds = new Set<Id>(m_deletedMapByType.get(sObjectType).keySet());
+			recordIds.retainAll(idSet);
+			return recordIds;
+		}
+		else
+		{
+			return new Set<Id>();
+		}
+	}
 
     /**
      * Takes all the work that has been registered with the UnitOfWork and commits it to the database
@@ -401,6 +642,32 @@ public virtual class fflib_SObjectUnitOfWork
             onCommitWorkFinished(wasSuccessful);
         }
     }
+
+	/**
+	 * Retain All elements in the map with a key provided in the set of Ids
+	 *
+	 * @param recordMap The Map to process
+	 * @param idSet The Id's of elements that should remain
+	 */
+	private Map<Id, SObject> retainAllInMap(Map<Id, SObject> recordMap, Set<Id> idSet)
+	{
+		Set<Id> recordIds = new Set<Id>(recordMap.keySet());
+		if (recordIds.retainAll(idSet))
+		{
+			Map<Id, SObject> sObjectsByIds = new Map<Id, SObject>();
+			for (Id id : recordIds)
+			{
+				sObjectsByIds.put(id, recordMap.get(id));
+			}
+			return sObjectsByIds;
+		}
+		else
+		{
+			return new Map<Id, SObject>(recordMap);
+		}
+		return new Map<Id, sObject>();
+	}
+
 
     private class Relationships
     {

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -35,6 +35,125 @@ private with sharing class fflib_SObjectUnitOfWorkTest
             Opportunity.SObjectType,
             OpportunityLineItem.SObjectType };
 
+	@IsTest
+	private static void itShouldRetrieveACleanRecord()
+	{
+		// GIVEN a clean account
+		Account myAccount = new Account(Name = 'Test', Id = fflib_IDGenerator.generate(Account.SObjectType));
+		fflib_SObjectUnitOfWork unitOfWork = new fflib_SObjectUnitOfWork(new List<SObjectType> {Account.SObjectType});
+
+		// WHEN the clean account is registered to the unit of work and it becomes dirty due to a changed
+		unitOfWork.registerClean(myAccount);
+		myAccount.Name = 'Test A';
+		Map<Id, SObject> cleanRecords = unitOfWork.getClean(Account.SObjectType, new Set<Id> {myAccount.Id});
+
+		// THEN then the clean account in the unit of work should exist and be as it was, clean
+		System.assert(!cleanRecords.isEmpty(), 'Clean records were not stored or retrieved correctly from unit of work');
+		System.assert(cleanRecords.containsKey(myAccount.Id), 'Account record not found in unit of work as clean');
+		System.assertNotEquals(myAccount.Name, cleanRecords.get(myAccount.Id).get(Account.Name), 'Clean record seem to be dirty');
+	}
+
+	@IsTest
+	private static void itShouldRetrieveAMergedCleanRecord()
+	{
+		// GIVEN two the same clean accounts with different fields populated
+		Id accountId = fflib_IDGenerator.generate(Account.SObjectType);
+		Account accountA = new Account(Id = accountId, Name = 'Test', AccountNumber='12345');
+		Account accountB = new Account(Id = accountId, Name = 'Test', BillingCountry='Holland');
+		fflib_SObjectUnitOfWork unitOfWork = new fflib_SObjectUnitOfWork(new List<SObjectType> {Account.SObjectType});
+
+		// WHEN both accounts are registered as clean
+		unitOfWork.registerClean(new List<SObject> { accountA, accountB });
+		Map<Id, SObject> cleanRecords = unitOfWork.getClean(Account.SObjectType, new Set<Id> { accountId });
+
+		// THEN one record should be returned with all fields merged into the account
+		System.assert(!cleanRecords.isEmpty(), 'Clean records were not stored or retrieved correctly from unit of work');
+		System.assert(cleanRecords.containsKey(accountId), 'Account record not found in unit of work as clean');
+		System.assertEquals(4, cleanRecords.get(accountId).getPopulatedFieldsAsMap().size(), 'Incorrect number of field');
+	}
+
+	@IsTest
+	private static void itShouldRetrieveADirtyRecord()
+	{
+		// GIVEN a list of dirty accounts registered in the unit of work
+		fflib_SObjectUnitOfWork unitOfWork = new fflib_SObjectUnitOfWork(new List<SObjectType> {Account.SObjectType});
+		Account myAccountA = new Account(Name = 'Test A', Id = fflib_IDGenerator.generate(Account.SObjectType));
+		unitOfWork.registerDirty(
+				new List<Account>
+				{
+						myAccountA,
+						new Account(Name = 'Test B', Id = fflib_IDGenerator.generate(Account.SObjectType))
+				}
+		);
+
+		// WHEN a single dirty account is requested
+		Map<Id, SObject> dirtyRecords = unitOfWork.getDirty(Account.SObjectType, new Set<Id> {myAccountA.Id});
+
+		// THEN the dirty account record should be returned
+		System.assert(!dirtyRecords.isEmpty(), 'Should have had one record returned by the unit of work');
+		System.assert(dirtyRecords.containsKey(myAccountA.Id), 'Incorrect returned account');
+	}
+
+	@IsTest
+	private static void itShouldRetrieveADeletedRecord()
+	{
+		// GIVEN a list of deleted accounts registered in the unit of work
+		fflib_SObjectUnitOfWork unitOfWork = new fflib_SObjectUnitOfWork(new List<SObjectType> {Account.SObjectType});
+		Account myAccountA = new Account(Name = 'Test A', Id = fflib_IDGenerator.generate(Account.SObjectType));
+		unitOfWork.registerDeleted(
+				new List<Account>
+				{
+						myAccountA,
+						new Account(Name = 'Test B', Id = fflib_IDGenerator.generate(Account.SObjectType))
+				}
+		);
+
+		// WHEN a list of possible deleted account id's is requested
+		Set<Id> accountIds = new Set<Id>
+		{
+				myAccountA.Id,
+				fflib_IDGenerator.generate(Account.SObjectType)
+		};
+		Map<Id, SObject> deletedRecords = unitOfWork.getDeleted(Account.SObjectType, accountIds);
+		Set<Id> deletedRecordIds = unitOfWork.getDeletedIds(Account.SObjectType, accountIds);
+
+		// THEN only the registered account for deletion should be returned
+		System.assert(!deletedRecords.isEmpty(), 'Should have one deleted record');
+		System.assert(!deletedRecordIds.isEmpty(), 'Should have one deleted record');
+		System.assert(deletedRecords.containsKey(myAccountA.Id), 'Deleted account not returned');
+	}
+
+	@IsTest
+	private static void itShouldOnlyRegisterDirtyFieldsBasedOnCleanRecord()
+	{
+		// GIVEN a clean and dirty registered version of the same record in the unit of work
+		fflib_SObjectUnitOfWork unitOfWork = new fflib_SObjectUnitOfWork(new List<SObjectType> {Account.SObjectType});
+		Id accountId = fflib_IDGenerator.generate(Account.SObjectType);
+		Account accountA = new Account(Id = accountId, Name = 'Test', AccountNumber='12345', BillingCountry='Holland');
+		Account accountB = new Account(Id = accountId, Name = 'Test', AccountNumber='12345');
+		unitOfWork.registerClean(accountA);
+		accountA.Name = 'Test A';
+		unitOfWork.registerDirty(accountA);
+
+		// WHEN the another dirty version is registered
+		accountB.AccountNumber = '54321';
+		unitOfWork.registerDirty(
+				new List<SObject>
+				{
+						accountB,
+						new Account(Id = fflib_IDGenerator.generate(Account.SObjectType), Name = 'Just another account')
+				});
+
+		// THEN it should only register the changed field, and not overwrite the first dirty registered fields
+		Map<Id, SObject> dirtyRecords = unitOfWork.getDirty(Account.SObjectType, new Set<Id> {accountId});
+		System.assert(!dirtyRecords.isEmpty(), 'Should have one dirty record');
+		System.assert(dirtyRecords.containsKey(accountId), 'Dirty account not returned');
+		System.assertEquals(
+				new Account(Id = accountId, Name = 'Test A', AccountNumber='54321', BillingCountry='Holland'),
+				dirtyRecords.get(accountId),
+				'Merge failed of dirty accounts');
+	}
+
     @isTest
     private static void testUnitOfWorkEmail()
     {


### PR DESCRIPTION
I noticed that recently the UnitOfWork registerDirty method got an additional parameter 'dirtyFields'. That is a very good improvement, but what if you are not so fortunate to know the exact list of changed fields then the Identity map design pattern that I implemented might be helpful. 
With the added registerClean method the UnitOfWork can recognise the dirty fields automatically.

When you like this change I can also add an extra option to the Selector functionality to automatically store queried records as clean records in the UnitOfWork. Then we really can make use of the full potential of the Identity map design pattern, because then we have enabled a type of caching. A record queried for the second time would then be fetched from the Identity map, instead of queried in the database.

Please let me know your thoughts about his change