### PR TITLE
Alleviates unit-test exception when Org's email service is limited.

### DIFF
--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -66,7 +66,8 @@ public virtual class fflib_SObjectUnitOfWork
 
     protected List<IDoWork> m_workList = new List<IDoWork>();
 
-    protected SendEmailWork m_emailWork = new SendEmailWork();
+    @TestVisible
+    protected IEmailWork m_emailWork = new SendEmailWork();
 
     protected IDML m_dml;
 
@@ -107,7 +108,6 @@ public virtual class fflib_SObjectUnitOfWork
         this(sObjectTypes,new SimpleDML());
     }
 
-
     public fflib_SObjectUnitOfWork(List<Schema.SObjectType> sObjectTypes, IDML dml)
     {
         m_sObjectTypes = sObjectTypes.clone();
@@ -119,8 +119,6 @@ public virtual class fflib_SObjectUnitOfWork
         }
 
         m_relationships.put( Messaging.SingleEmailMessage.class.getName(), new Relationships());
-
-        m_workList.add(m_emailWork);
 
         m_dml = dml;
     }
@@ -377,6 +375,7 @@ public virtual class fflib_SObjectUnitOfWork
             // notify we're starting to process registered work
             onDoWorkStarting();
             // Generic work
+            m_workList.add(m_emailWork);
             for(IDoWork work : m_workList)
                 work.doWork();
             // notify we've completed processing registered work
@@ -472,7 +471,12 @@ public virtual class fflib_SObjectUnitOfWork
     /**
      * Internal implementation of Messaging.sendEmail, see outer class registerEmail method
      **/
-    private class SendEmailWork implements IDoWork
+    public interface IEmailWork extends IDoWork
+    {
+        void registerEmail(Messaging.Email email);
+    }
+
+    private class SendEmailWork implements IEmailWork
     {
         private List<Messaging.Email> emails;
 

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -46,6 +46,8 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 
         fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
 
+        uow.m_emailWork = new Mock_SendEmailWork();
+
         Opportunity opp = new Opportunity();
         opp.Name = testRecordName;
         opp.StageName = 'Open';
@@ -60,8 +62,8 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 
         List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name = :testRecordName order by Name];
 
-        // assert that an email was sent
-        system.assertEquals(1, Limits.getEmailInvocations());
+        // assert that mock email functionality was called
+        system.assert(((Mock_SendEmailWork) uow.m_emailWork).doWorkWasCalled);
 
         System.assertEquals(1, opps.size());
     }
@@ -503,6 +505,30 @@ private with sharing class fflib_SObjectUnitOfWorkTest
         {
             addEvent('onCommitWorkFinished - ' + wasSuccessful);
         }
+    }
+
+    /**
+     * Mock implementation of fflib_SObjectUnitOfWork.SendEmailWork
+     **/
+    private class Mock_SendEmailWork implements fflib_SObjectUnitOfWork.IEmailWork
+    {
+        public Mock_SendEmailWork()
+        {
+        }
+
+        public void registerEmail(Messaging.Email email)
+        {
+        }
+
+        public void doWork()
+        {
+            doWorkWasCalled = true;
+            // The code in the fflib_SObjectUnitOfWork class
+            // causes unit test failures in Orgs that do not
+            // have email enabled.
+        }
+
+        private boolean doWorkWasCalled = false;
     }
 
     public class DerivedUnitOfWorkException extends Exception {}


### PR DESCRIPTION
The following unit-test caused exception occurs when the org's email deliverability's 'Access Level' setting is not 'All Email'.

`System.EmailException: SendEmail failed. First exception on row 0; first error: NO_MASS_MAIL_PERMISSION, Single email is not enabled for your organization or profile.: []`

This fix uses mock, send-email class, which verifies DoWork method was called, presuming the platform's Messaging feature functions, as intended and used in the default SendEmailWork class.

Attempted to use the FFLIB Apex Mocks functionality to mock the new IEmailWork interface, but Test.createStub method generated an exception pertaining inner classes not being supported.