### PR TITLE
Default Sorting considering invalid field and shield

### DIFF
--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -69,7 +69,7 @@ public abstract with sharing class fflib_SObjectSelector
      * Switch this off if you need more performant queries.
      **/
     private Boolean m_sortSelectFields;
-  
+
    /**
    * Describe helper
    **/
@@ -81,7 +81,13 @@ public abstract with sharing class fflib_SObjectSelector
    		}
    		set;
    	}
-   	 
+   	/**
+   	* static variables
+    **/
+
+   	protected static String DEFAULT_SORT_FIELD = 'CreatedDate';
+   	protected static String SF_ID_FIELD = 'Id';
+
     /**
      * Implement this method to inform the base class of the SObject (custom or standard) to be queried
      **/
@@ -148,7 +154,7 @@ public abstract with sharing class fflib_SObjectSelector
 	 * Override this method to control the default ordering of records returned by the base queries,
 	 * defaults to the name field of the object if it is not encrypted or CreatedDate if there the object has createdDated or Id
 	 **/
-    public virtual String getOrderBy()
+     public virtual String getOrderBy()
     {
         if (m_orderBy == null)
         {
@@ -159,19 +165,16 @@ public abstract with sharing class fflib_SObjectSelector
             }
             else
             {
-                m_orderBy = 'CreatedDate';
-                //Tahsin Zulkarnine: Check whether createdDate field exists in the object. Certain object might not have it, ie AccountShare, etc
-                Boolean invalidField = false;
-                try
+                m_orderBy = DEFAULT_SORT_FIELD;
+                try {
+                    if (describeWrapper.getField(m_orderBy) == null)
                     {
-                        if(describeWrapper.getField(m_orderBy) == null) invalidField = true;
+                        m_orderBy = SF_ID_FIELD;
+                    }
                 }
-                catch(fflib_QueryFactory.InvalidFieldException ex){
-                    // Tahsin Zulkarnine: if not found, making the default field to Id as all saleforce object has id
-                    invalidField = true;
+                catch(fflib_QueryFactory.InvalidFieldException ex) {
+                    m_orderBy = SF_ID_FIELD;
                 }
-                if(invalidField)	m_orderBy = 'Id';
-
             }
         }
         return m_orderBy;

--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -47,17 +47,17 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * Should this selector automatically include the FieldSet fields when building queries?
      **/
-    protected Boolean m_includeFieldSetFields;
+    private Boolean m_includeFieldSetFields;
     
     /**
      * Enforce FLS Security
      **/
-    protected Boolean m_enforceFLS;
+    private Boolean m_enforceFLS;
 
     /**
      * Enforce CRUD Security
      **/
-    protected Boolean m_enforceCRUD;
+    private Boolean m_enforceCRUD;
    	
     /**
      * Order by field
@@ -84,8 +84,8 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * static variables
      **/
-    protected static String DEFAULT_SORT_FIELD = 'CreatedDate';
-    protected static String SF_ID_FIELD = 'Id';
+    private static String DEFAULT_SORT_FIELD = 'CreatedDate';
+    private static String SF_ID_FIELD = 'Id';
 
     /**
      * Implement this method to inform the base class of the SObject (custom or standard) to be queried
@@ -405,7 +405,7 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * Configures a QueryFactory instance according to the configuration of this selector
      **/        
-    protected fflib_QueryFactory configureQueryFactory(fflib_QueryFactory queryFactory, Boolean assertCRUD, Boolean enforceFLS, Boolean includeSelectorFields)
+    private fflib_QueryFactory configureQueryFactory(fflib_QueryFactory queryFactory, Boolean assertCRUD, Boolean enforceFLS, Boolean includeSelectorFields)
     {
         // CRUD and FLS security required?
         if (assertCRUD)

--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -52,17 +52,17 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * Enforce FLS Security
      **/
-   	protected Boolean m_enforceFLS;
+    protected Boolean m_enforceFLS;
 
     /**
      * Enforce CRUD Security
      **/
-   	protected Boolean m_enforceCRUD;
+    protected Boolean m_enforceCRUD;
    	
-   /**
-    * Order by field
-    **/
-    	private String m_orderBy;
+    /**
+     * Order by field
+     **/
+    private String m_orderBy;
 
     /**
      * Sort the query fields in the select statement (defaults to true, at the expense of performance).
@@ -70,23 +70,22 @@ public abstract with sharing class fflib_SObjectSelector
      **/
     private Boolean m_sortSelectFields;
 
-   /**
-   * Describe helper
-   **/
-   	private fflib_SObjectDescribe describeWrapper {
-   		get {
-   			if(describeWrapper == null)
-   				describeWrapper = fflib_SObjectDescribe.getDescribe(getSObjectType());
-   			return describeWrapper;
-   		}
-   		set;
+    /**
+     * Describe helper
+     **/
+    private fflib_SObjectDescribe describeWrapper {
+	get {
+		if(describeWrapper == null)
+			describeWrapper = fflib_SObjectDescribe.getDescribe(getSObjectType());
+		return describeWrapper;
+	}
+	set;
    	}
-   	/**
-   	* static variables
-    **/
-
-   	protected static String DEFAULT_SORT_FIELD = 'CreatedDate';
-   	protected static String SF_ID_FIELD = 'Id';
+    /**
+     * static variables
+     **/
+    protected static String DEFAULT_SORT_FIELD = 'CreatedDate';
+    protected static String SF_ID_FIELD = 'Id';
 
     /**
      * Implement this method to inform the base class of the SObject (custom or standard) to be queried
@@ -150,12 +149,12 @@ public abstract with sharing class fflib_SObjectSelector
         return null;
     }
 
-    /**
-	 * Override this method to control the default ordering of records returned by the base queries,
-	 * defaults to the name field of the object if it is not encrypted or CreatedDate if there the object has createdDated or Id
-	 **/
+     /**
+      * Override this method to control the default ordering of records returned by the base queries,
+      * defaults to the name field of the object if it is not encrypted or CreatedDate if there the object has createdDated or Id
+      **/
      public virtual String getOrderBy()
-    {
+     {
         if (m_orderBy == null)
         {
             Schema.SObjectField nameField = describeWrapper.getNameField();
@@ -341,20 +340,20 @@ public abstract with sharing class fflib_SObjectSelector
         		assertCRUD, enforceFLS, includeSelectorFields);
     }
 
-	/**
-	 * Adds the selectors fields to the given QueryFactory using the given relationship path as a prefix
-	 *
-	 * // TODO: This should be consistant (ideally) with configureQueryFactory below
-	 **/
-	public void configureQueryFactoryFields(fflib_QueryFactory queryFactory, String relationshipFieldPath)
-	{
-		// Add fields from selector prefixing the relationship path		
-		for(SObjectField field : getSObjectFieldList())		
-        	queryFactory.selectField(relationshipFieldPath + '.' + field.getDescribe().getName());
-        // Automatically select the CurrencyIsoCode for MC orgs (unless the object is a known exception to the rule)
+     /**
+      * Adds the selectors fields to the given QueryFactory using the given relationship path as a prefix
+      *
+      * // TODO: This should be consistant (ideally) with configureQueryFactory below
+      **/
+     public void configureQueryFactoryFields(fflib_QueryFactory queryFactory, String relationshipFieldPath)
+     {
+	// Add fields from selector prefixing the relationship path		
+	for(SObjectField field : getSObjectFieldList())		
+	queryFactory.selectField(relationshipFieldPath + '.' + field.getDescribe().getName());
+	// Automatically select the CurrencyIsoCode for MC orgs (unless the object is a known exception to the rule)
         if(Userinfo.isMultiCurrencyOrganization() && CURRENCY_ISO_CODE_ENABLED)
             queryFactory.selectField(relationshipFieldPath+'.CurrencyIsoCode');		
-	}
+     }
     
     /**
      * Adds a subselect QueryFactory based on this selector to the given QueryFactor, returns the parentQueryFactory
@@ -378,22 +377,22 @@ public abstract with sharing class fflib_SObjectSelector
     		includeSelectorFields);
     }
         
-	/**
-	 * Adds a subselect QueryFactory based on this selector to the given QueryFactor, returns the parentQueryFactory
-	 **/
-	public fflib_QueryFactory addQueryFactorySubselect(fflib_QueryFactory parentQueryFactory, String relationshipName)
-	{
-		return addQueryFactorySubselect(parentQueryFactory, relationshipName, TRUE);
-	}
+     /**
+      * Adds a subselect QueryFactory based on this selector to the given QueryFactor, returns the parentQueryFactory
+      **/
+     public fflib_QueryFactory addQueryFactorySubselect(fflib_QueryFactory parentQueryFactory, String relationshipName)
+     {
+	return addQueryFactorySubselect(parentQueryFactory, relationshipName, TRUE);
+     }
 
-	/**
-	 * Adds a subselect QueryFactory based on this selector to the given QueryFactor
-	 **/
-	public fflib_QueryFactory addQueryFactorySubselect(fflib_QueryFactory parentQueryFactory, String relationshipName, Boolean includeSelectorFields)
-	{
-		fflib_QueryFactory subSelectQueryFactory = parentQueryFactory.subselectQuery(relationshipName);
-		return configureQueryFactory(subSelectQueryFactory, m_enforceCRUD, m_enforceFLS, includeSelectorFields);
-	}
+     /**
+       * Adds a subselect QueryFactory based on this selector to the given QueryFactor
+       **/
+     public fflib_QueryFactory addQueryFactorySubselect(fflib_QueryFactory parentQueryFactory, String relationshipName, Boolean includeSelectorFields)
+     {
+	fflib_QueryFactory subSelectQueryFactory = parentQueryFactory.subselectQuery(relationshipName);
+	return configureQueryFactory(subSelectQueryFactory, m_enforceCRUD, m_enforceFLS, includeSelectorFields);
+     }
 
     /**
      * Constructs the default SOQL query for this selector, see selectSObjectsById and queryLocatorById
@@ -403,9 +402,9 @@ public abstract with sharing class fflib_SObjectSelector
         return newQueryFactory().setCondition('id in :idSet').toSOQL();
     }
     	
-	/**
-	 * Configures a QueryFactory instance according to the configuration of this selector
-	 **/        
+    /**
+     * Configures a QueryFactory instance according to the configuration of this selector
+     **/        
     protected fflib_QueryFactory configureQueryFactory(fflib_QueryFactory queryFactory, Boolean assertCRUD, Boolean enforceFLS, Boolean includeSelectorFields)
     {
         // CRUD and FLS security required?

--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -47,17 +47,17 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * Should this selector automatically include the FieldSet fields when building queries?
      **/
-    private Boolean m_includeFieldSetFields;
+    protected Boolean m_includeFieldSetFields;
     
     /**
      * Enforce FLS Security
      **/
-   	private Boolean m_enforceFLS;
+   	protected Boolean m_enforceFLS;
 
     /**
      * Enforce CRUD Security
      **/
-   	private Boolean m_enforceCRUD;
+   	protected Boolean m_enforceCRUD;
    	
    /**
     * Order by field
@@ -143,20 +143,38 @@ public abstract with sharing class fflib_SObjectSelector
     {
         return null;
     }
-    
+
     /**
-     * Override this method to control the default ordering of records returned by the base queries, 
-     * defaults to the name field of the object or CreatedDate if there is none
-     **/
+	 * Override this method to control the default ordering of records returned by the base queries,
+	 * defaults to the name field of the object if it is not encrypted or CreatedDate if there the object has createdDated or Id
+	 **/
     public virtual String getOrderBy()
     {
-        if(m_orderBy == null) {
-   		m_orderBy = 'CreatedDate';
-   		if(describeWrapper.getNameField() != null) {
-	    		m_orderBy = describeWrapper.getNameField().getDescribe().getName();
-	    	}
-	}
-   	return m_orderBy;
+        if (m_orderBy == null)
+        {
+            Schema.SObjectField nameField = describeWrapper.getNameField();
+            if (nameField != null && !nameField.getDescribe().isEncrypted())
+            {
+                m_orderBy = nameField.getDescribe().getName();
+            }
+            else
+            {
+                m_orderBy = 'CreatedDate';
+                //Tahsin Zulkarnine: Check whether createdDate field exists in the object. Certain object might not have it, ie AccountShare, etc
+                Boolean invalidField = false;
+                try
+                    {
+                        if(describeWrapper.getField(m_orderBy) == null) invalidField = true;
+                }
+                catch(fflib_QueryFactory.InvalidFieldException ex){
+                    // Tahsin Zulkarnine: if not found, making the default field to Id as all saleforce object has id
+                    invalidField = true;
+                }
+                if(invalidField)	m_orderBy = 'Id';
+
+            }
+        }
+        return m_orderBy;
     }
 
     /** 
@@ -385,7 +403,7 @@ public abstract with sharing class fflib_SObjectSelector
 	/**
 	 * Configures a QueryFactory instance according to the configuration of this selector
 	 **/        
-    private fflib_QueryFactory configureQueryFactory(fflib_QueryFactory queryFactory, Boolean assertCRUD, Boolean enforceFLS, Boolean includeSelectorFields)
+    protected fflib_QueryFactory configureQueryFactory(fflib_QueryFactory queryFactory, Boolean assertCRUD, Boolean enforceFLS, Boolean includeSelectorFields)
     {
         // CRUD and FLS security required?
         if (assertCRUD)


### PR DESCRIPTION
Financial Force library (FFLIB) by default sorts record based on CreatedDate. Some object (ie. account share) might not have the field and hence will through error.  This change checks the field encryption (taken from @wimvelzeboer ) and if the object does not have created date field, assigns Id as default sorting field.

Also, to ensure the inheritance for sobject selector (where FFLIB is used a different package or SFDX folder), certain variables has been changed from private to protected.